### PR TITLE
Fix FineTunesApi event streaming invocation.

### DIFF
--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/FineTunesApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/FineTunesApi.kt
@@ -71,10 +71,10 @@ internal class FineTunesApi(private val requester: HttpRequester) : FineTunes {
     override fun fineTuneEventsFlow(fineTuneId: FineTuneId): Flow<FineTuneEvent> {
         return streamEventsOf {
             requester.perform {
-                it.post {
-                    url(path = "$FineTunesPathV1/${fineTuneId.id}/events")
-                    setBody(mapOf("stream" to true))
-                    contentType(ContentType.Application.Json)
+                it.get {
+                    url(path = "$FineTunesPathV1/${fineTuneId.id}/events") {
+                        parameters.append("stream", "true")
+                    }
                 }
             }
         }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no 
| BC breaks?        | no
| Related Issue | n/a



## Describe your change

Although currently implemented as a `POST` operation, the docs indicate that the `stream` parameter should be provided as a query parameter on the `GET` operation: https://beta.openai.com/docs/api-reference/fine-tunes/events#fine-tunes/events-stream.

## What problem is this fixing?

Currently, invoking the `fineTuneEventsFlow` invariably yields at `403` response from openai.