### PR TITLE
fix: start emit flow without waiting for SSE full response

### DIFF
--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/extension/Stream.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/extension/Stream.kt
@@ -5,28 +5,27 @@ import io.ktor.client.call.body
 import io.ktor.client.statement.HttpResponse
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readUTF8Line
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.serialization.decodeFromString
 
-private const val StreamPrefix = "data:"
-private const val StreamEndToken = "$StreamPrefix [DONE]"
+private const val STREAM_PREFIX = "data:"
+private const val STREAM_END_TOKEN = "$STREAM_PREFIX [DONE]"
 
 /**
- * Request data as [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format).
+ * Get data as [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format).
  */
-internal inline fun <reified T> streamEventsOf(crossinline block: suspend () -> HttpResponse): Flow<T> {
-    return flow {
-        val response = block()
-        val readChannel = response.body<ByteReadChannel>()
-        while (!readChannel.isClosedForRead) {
-            val line = readChannel.readUTF8Line() ?: ""
-            val value: T = when {
-                line.startsWith(StreamEndToken) -> break
-                line.startsWith(StreamPrefix) -> JsonLenient.decodeFromString(line.removePrefix(StreamPrefix))
-                else -> continue
-            }
-            emit(value)
+internal suspend inline fun <reified T> FlowCollector<T>.streamEventsFrom(response: HttpResponse) {
+    val channel: ByteReadChannel = response.body()
+    while (!channel.isClosedForRead) {
+        val line = channel.readUTF8Line() ?: continue
+        val value: T = when {
+            line.startsWith(STREAM_END_TOKEN) -> break
+            line.startsWith(STREAM_PREFIX) -> JsonLenient.decodeFromString(
+                line.removePrefix(STREAM_PREFIX)
+            )
+
+            else -> continue
         }
+        emit(value)
     }
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpRequester.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpRequester.kt
@@ -1,6 +1,7 @@
 package com.aallam.openai.client.internal.http
 
 import io.ktor.client.HttpClient
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.statement.HttpResponse
 import io.ktor.util.reflect.TypeInfo
 import io.ktor.util.reflect.typeInfo
@@ -14,6 +15,16 @@ internal interface HttpRequester {
      * Perform an HTTP request and get a result.
      */
     suspend fun <T : Any> perform(info: TypeInfo, block: suspend (HttpClient) -> HttpResponse): T
+
+    /**
+     * Perform an HTTP request and get a result.
+     *
+     * Note: [HttpResponse] instance shouldn't be passed outside of [block].
+     */
+    suspend fun <T : Any> perform(
+        builder: HttpRequestBuilder,
+        block: suspend (response: HttpResponse) -> T
+    )
 }
 
 /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #94   <!-- will close issue automatically, if any -->

## Describe your change

Start emitting flow events without waiting for the full HTTP response using `HttpStatement.execute`.

## What problem is this fixing?

Based on Ktor's [documentation](https://ktor.io/docs/response.html#streaming), `HttpResponse.body` waits for the full response before returning a result (including `HttpResponse.body<ByteReadChannel>()` and `response.bodyAsChannel()`), whch is not the desired behavior.
