### PR TITLE
feat(config): add retry strategy in case of rate limit

### DIFF
--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/OpenAI.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/OpenAI.kt
@@ -7,17 +7,7 @@ import com.aallam.openai.client.internal.http.HttpTransport
 /**
  * OpenAI API.
  */
-public interface OpenAI :
-    Completions,
-    Files,
-    Edits,
-    Embeddings,
-    Models,
-    Moderations,
-    FineTunes,
-    Images,
-    Chat,
-    Audio
+public interface OpenAI : Completions, Files, Edits, Embeddings, Models, Moderations, FineTunes, Images, Chat, Audio
 
 /**
  * Creates an instance of [OpenAI].

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/OpenAIConfig.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/OpenAIConfig.kt
@@ -18,7 +18,7 @@ import kotlin.time.Duration.Companion.seconds
  * @param host OpenAI host configuration
  * @param proxy HTTP proxy url
  * @param host OpenAI host configuration.
- * @param retry http retry strategy
+ * @param retry rate limit retry configuration
  */
 public class OpenAIConfig(
     public val token: String,
@@ -29,7 +29,7 @@ public class OpenAIConfig(
     public val headers: Map<String, String> = emptyMap(),
     public val host: OpenAIHost = OpenAIHost.OpenAI,
     public val proxy: ProxyConfig? = null,
-    public val retry: RetryStrategy = RetryStrategy.Exponential(),
+    public val retry: RetryStrategy = RetryStrategy(),
 )
 
 /**
@@ -59,38 +59,13 @@ public sealed interface ProxyConfig {
 
 /**
  * Specifies the retry strategy
+ *
+ * @param maxRetries the maximum amount of retries to perform for a request
+ * @param base retry base value
+ * @param maxDelay max retry delay
  */
-public sealed interface RetryStrategy {
-
-    /** The maximum amount of retries to perform for a request. */
-    public val maxRetries: Int
-
-    /**
-     * Specifies an exponential delay between retries
-     *
-     * @param maxRetries the maximum amount of retries to perform for a request
-     * @param base exponential base value
-     * @param maxDelay max retry delay
-     */
-    public class Exponential(
-        public override val maxRetries: Int = 3,
-        public val base: Double = 2.0,
-        public val maxDelay: Duration = 60.seconds,
-    ) : RetryStrategy
-
-    /**
-     * Specifies a constant delay between retries
-     *
-     * @param maxRetries the maximum amount of retries to perform for a request
-     * @param delay retry delay duration
-     */
-    public class Constant(
-        public override val maxRetries: Int = 3,
-        public val delay: Duration = 1.seconds,
-    ) : RetryStrategy
-
-    /** Disables retry. */
-    public object NoRetry : RetryStrategy {
-        override val maxRetries: Int = 0
-    }
-}
+public class RetryStrategy(
+    public val maxRetries: Int = 3,
+    public val base: Double = 2.0,
+    public val maxDelay: Duration = 60.seconds,
+)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #107 

## Describe your change

- Add request retry in case of rate limit errors (following the [docs](https://help.openai.com/en/articles/6891753-rate-limit-advice) recommendations).
- Add `RetryStrategy` and `OpenAIConfig.retry`