### PR TITLE
feat: Added handling for OpenAI API errors

### DIFF
--- a/openai-client/src/jvmTest/kotlin/com/aallam/openai/api/exception/OpenAIAPIExceptionTest.kt
+++ b/openai-client/src/jvmTest/kotlin/com/aallam/openai/api/exception/OpenAIAPIExceptionTest.kt
@@ -1,0 +1,42 @@
+package com.aallam.openai.api.exception
+
+import com.aallam.openai.api.model.ModelId
+import com.aallam.openai.client.OpenAI
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+
+class OpenAIAPIExceptionTest {
+
+    /**
+     *
+     ```
+        {
+        "error": {
+            "message": "Incorrect API key provided: 12. You can find your API key at https://platform.openai.com/account/api-keys.",
+            "type": "invalid_request_error",
+            "param": null,
+            "code": "invalid_api_key"
+            }
+        }
+     ```
+     */
+    @Test
+    fun `test OpenAI API Error`() = runBlocking {
+        val openAI = OpenAI("sk-123")
+        val model = kotlin.runCatching {
+            openAI.model(ModelId("davinci"))
+        }
+        assert(model.isFailure)
+        val exception = model.exceptionOrNull()?.cause as OpenAIAPIException
+        assertEquals(401, exception.statusCode)
+        assertEquals(
+            "invalid_request_error",
+            exception.openAIAPIError.error?.type
+        )
+        assertEquals(
+            "invalid_api_key",
+            exception.openAIAPIError.error?.code
+        )
+    }
+}

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/exception/Error.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/exception/Error.kt
@@ -1,0 +1,17 @@
+package com.aallam.openai.api.exception
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class Error(
+    @SerialName("code")
+    val code: String?,
+    @SerialName("message")
+    val message: String?,
+    @SerialName("param")
+    val `param`: String?,
+    @SerialName("type")
+    val type: String?
+)

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/exception/OpenAIAPIError.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/exception/OpenAIAPIError.kt
@@ -1,0 +1,11 @@
+package com.aallam.openai.api.exception
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class OpenAIAPIError(
+    @SerialName("error")
+    val error: Error?
+)

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/exception/OpenAIException.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/exception/OpenAIException.kt
@@ -14,6 +14,7 @@ public class OpenAIHttpException(
 
 /** Runtime API exception */
 public class OpenAIAPIException(
-    statusCode: Int,
-    body: String,
+    public val statusCode: Int,
+    public val body: String,
+    public val openAIAPIError: OpenAIAPIError,
 ) : OpenAIException(message = "(statusCode=$statusCode, body='$body')")


### PR DESCRIPTION
…for easier error handling by users. Also added additional test cases.

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | Fix #114 

## Describe your change


Added handling for OpenAI API errors, serialized as data class for easier error handling by users. Also added additional test cases.

## What problem is this fixing?

For library users, receiving pre-serialized error types and information when exceptions occur will make it easier to determine and handle errors. If only converted to strings, users would need to use regex to obtain the status code and error information, which could be more cumbersome.