### PR TITLE
fix: switch mixed-up audio translation and transcription paths

### DIFF
--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/AudioApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/AudioApi.kt
@@ -18,7 +18,7 @@ internal class AudioApi(val requester: HttpRequester) : Audio {
     @BetaOpenAI
     override suspend fun transcription(request: TranscriptionRequest): Transcription {
         return requester.perform {
-            it.submitFormWithBinaryData(url = TranslationPathV1, formData = formDataOf(request))
+            it.submitFormWithBinaryData(url = TranscriptionPathV1, formData = formDataOf(request))
         }
     }
 
@@ -37,7 +37,7 @@ internal class AudioApi(val requester: HttpRequester) : Audio {
     @BetaOpenAI
     override suspend fun translation(request: TranslationRequest): Translation {
         return requester.perform {
-            it.submitFormWithBinaryData(url = TranscriptionPathV1, formData = formDataOf(request))
+            it.submitFormWithBinaryData(url = TranslationPathV1, formData = formDataOf(request))
         }
     }
 

--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestAudio.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestAudio.kt
@@ -1,6 +1,7 @@
 package com.aallam.openai.client
 
 import com.aallam.openai.api.audio.transcriptionRequest
+import com.aallam.openai.api.audio.translationRequest
 import com.aallam.openai.api.file.FileSource
 import com.aallam.openai.api.model.ModelId
 import com.aallam.openai.client.internal.asSource
@@ -37,14 +38,14 @@ class TestAudio : TestOpenAI() {
     fun translation() = runTest {
         val multilingualUrl = "https://github.com/aallam/sample-data/raw/main/openai/audio/multilingual.wav"
         val audioBytes: ByteArray = httpClient.get(multilingualUrl).body()
-        val request = transcriptionRequest {
+        val request = translationRequest {
             audio = FileSource(name = "multilingual.wav", source = audioBytes.asSource())
             model = ModelId("whisper-1")
         }
-        val transcription = openAI.transcription(request)
-        assertTrue { transcription.text.isNotEmpty() }
+        val translation = openAI.translation(request)
+        assertTrue { translation.text.isNotEmpty() }
         assertTrue {
-            transcription.text.startsWith(
+            translation.text.startsWith(
                 "Whisper is an automatic recognition system of speech",
                 ignoreCase = true,
             )


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    
| BC breaks?        | no
| Related Issue     | Fix #118

## Describe your change

This change switches the mixed-up paths for audio translation and transcription and also fixes the translation test.

## What problem is this fixing?

The translation and transcription paths in https://github.com/aallam/openai-kotlin/blob/main/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/AudioApi.kt are mixed up. 