### PR TITLE
fix: correct gradle configuration file name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ capabilities.
 
 ## 📦 Setup
 
-1. Install OpenAI API Kotlin client by adding the following dependency to your `gradle.build` file:
+1. Install OpenAI API Kotlin client by adding the following dependency to your `build.gradle` file:
 
 ```groovy
 repositories {
@@ -25,7 +25,7 @@ dependencies {
 
 #### BOM
 
-Alternatively, you can use [openai-client-bom](/openai-client-bom)  by adding the following dependency to your `gradle.build` file
+Alternatively, you can use [openai-client-bom](/openai-client-bom)  by adding the following dependency to your `build.gradle` file
 
 ```groovy
 dependencies {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      |no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     |  <!-- will close issue automatically, if any -->

## Describe your change

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

Corrected gradle configuration file name in README.md from `gradle.build` to `build.gradle`.