### PR TITLE
chore: add more detailed api exceptions

### DIFF
--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpTransport.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpTransport.kt
@@ -1,9 +1,6 @@
 package com.aallam.openai.client.internal.http
 
-import com.aallam.openai.api.exception.OpenAIAPIException
-import com.aallam.openai.api.exception.OpenAIHttpException
-import com.aallam.openai.api.exception.OpenAIServerException
-import com.aallam.openai.api.exception.OpenAITimeoutException
+import com.aallam.openai.api.exception.*
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.network.sockets.*
@@ -41,12 +38,32 @@ internal class HttpTransport(private val httpClient: HttpClient) : HttpRequester
         httpClient.close()
     }
 
-    /** Handle different error cases. */
-    private suspend fun handleException(e: Exception) = when (e) {
+    /**
+     * Handles various exceptions that can occur during an API request and converts them into appropriate
+     * [OpenAIException] instances.
+     */
+    private suspend fun handleException(e: Throwable) = when (e) {
         is CancellationException -> e // propagate coroutine cancellation
-        is ClientRequestException -> OpenAIAPIException(e.response.status.value, e.response.body(), e)
+        is ClientRequestException -> openAIAPIException(e)
         is ServerResponseException -> OpenAIServerException(e)
         is HttpRequestTimeoutException, is SocketTimeoutException, is ConnectTimeoutException -> OpenAITimeoutException(e)
         else -> OpenAIHttpException(e)
+    }
+
+    /**
+     * Converts a [ClientRequestException] into a corresponding [OpenAIAPIException] based on the HTTP status code.
+     * This function helps in handling specific API errors and categorizing them into appropriate exception classes.
+     */
+    private suspend fun openAIAPIException(exception: ClientRequestException): OpenAIAPIException {
+        val response = exception.response
+        val status = response.status.value
+        val error = response.body<OpenAIError>()
+        return when(status) {
+            429 -> RateLimitException(status, error, exception)
+            400, 404, 415 -> InvalidRequestException(status, error, exception)
+            401 -> AuthenticationException(status, error, exception)
+            403 -> PermissionException(status, error, exception)
+            else -> UnknownAPIException(status, error, exception)
+        }
     }
 }

--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestException.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestException.kt
@@ -1,10 +1,12 @@
 package com.aallam.openai.client
 
+import com.aallam.openai.api.exception.AuthenticationException
 import com.aallam.openai.api.exception.OpenAIAPIException
 import com.aallam.openai.api.model.ModelId
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class TestException {
@@ -17,6 +19,7 @@ class TestException {
         }
         assertTrue(model.isFailure)
         val exception = model.exceptionOrNull() as OpenAIAPIException
+        assertIs<AuthenticationException>(exception)
         assertEquals(401, exception.statusCode)
         assertEquals(
             "invalid_request_error",

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/exception/OpenAIException.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/exception/OpenAIException.kt
@@ -12,15 +12,62 @@ public class OpenAIHttpException(
 ) : OpenAIException(throwable?.message, throwable)
 
 /**
- * An exception thrown when an error occurs while interacting with the OpenAI API.
+ * Represents an exception thrown when an error occurs while interacting with the OpenAI API.
+ *
+ * @property statusCode the HTTP status code associated with the error.
+ * @property error an instance of [OpenAIError] containing information about the error that occurred.
  */
-public class OpenAIAPIException(
-    /** Http status code **/
+public sealed class OpenAIAPIException(
     public val statusCode: Int,
-    /** Contains information about the error that occurred.*/
     public val error: OpenAIError,
     throwable: Throwable? = null,
 ) : OpenAIException(message = error.detail?.message, throwable = throwable)
+
+/**
+ * Represents an exception thrown when the OpenAI API rate limit is exceeded.
+ */
+public class RateLimitException(
+    statusCode: Int,
+    error: OpenAIError,
+    throwable: Throwable? = null
+): OpenAIAPIException(statusCode, error, throwable)
+
+/**
+ * Represents an exception thrown when an invalid request is made to the OpenAI API.
+ */
+public class InvalidRequestException(
+    statusCode: Int,
+    error: OpenAIError,
+    throwable: Throwable? = null
+): OpenAIAPIException(statusCode, error, throwable)
+
+/**
+ * Represents an exception thrown when an authentication error occurs while interacting with the OpenAI API.
+ */
+public class AuthenticationException(
+    statusCode: Int,
+    error: OpenAIError,
+    throwable: Throwable? = null
+): OpenAIAPIException(statusCode, error, throwable)
+
+/**
+ * Represents an exception thrown when a permission error occurs while interacting with the OpenAI API.
+ */
+public class PermissionException(
+    statusCode: Int,
+    error: OpenAIError,
+    throwable: Throwable? = null
+): OpenAIAPIException(statusCode, error, throwable)
+
+/**
+ * Represents an exception thrown when an unknown error occurs while interacting with the OpenAI API.
+ * This exception is used when the specific type of error is not covered by the existing subclasses.
+ */
+public class UnknownAPIException(
+    statusCode: Int,
+    error: OpenAIError,
+    throwable: Throwable? = null
+): OpenAIAPIException(statusCode, error, throwable)
 
 /** An exception thrown in case a request times out. */
 public class OpenAITimeoutException(


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | rno
| New feature?      | yes/no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #159

## Describe your change

Add more detailed exceptions for API errors to the sealed class `OpenAIAPIException`:
- `RateLimitException`: represents an exception thrown when the rate limit is exceeded
- `InvalidRequestException`: represents an exception thrown when an invalid request is made
- `AuthenticationException`: represents an exception thrown when an authentication error occurs
- `PermissionException`: represents an exception thrown when a permission error occurs
- `UnknownAPIException` : represents an exception thrown when an unknown error occurs, rhis exception is used when the specific type of error is not covered by the existing subclasses.