### PR TITLE
feat(host): add support of azure hosts

### DIFF
--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/OpenAIConfig.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/OpenAIConfig.kt
@@ -63,18 +63,48 @@ public class OpenAIConfig(
 }
 
 /**
- * OpenAI host configuration.
+ * A class to configure the OpenAI host.
+ * It provides a mechanism to customize the base URL and additional query parameters used in OpenAI API requests.
  */
 public class OpenAIHost(
-    /** Base URL configuration.*/
+
+    /**
+     * Base URL configuration.
+     * This is the root URL that will be used for all API requests to OpenAI.
+     * The URL can include a base path, but in that case, the base path should always end with a `/`.
+     * For example, a valid base URL would be "https://api.openai.com/v1/"
+     */
     public val baseUrl: String,
-    /** Additional query parameters */
+
+    /**
+     * Additional query parameters to be appended to all API requests to OpenAI.
+     * These can be used to provide additional configuration or context for the API requests.
+     */
     public val queryParams: Map<String, String> = emptyMap()
 ) {
+
     public companion object {
-        public val OpenAI: OpenAIHost = OpenAIHost("https://api.openai.com")
+        /**
+         * A pre-configured instance of [OpenAIHost] with the base URL set as `https://api.openai.com/v1/`.
+         */
+        public val OpenAI: OpenAIHost = OpenAIHost(baseUrl = "https://api.openai.com/v1/")
+
+        /**
+         * Creates an instance of [OpenAIHost] configured for Azure hosting with the given resource name, deployment ID,
+         * and API version.
+         *
+         * @param resourceName The name of your Azure OpenAI Resource.
+         * @param deploymentId The name of your model deployment.
+         * @param apiVersion The API version to use for this operation. This parameter should follow the YYYY-MM-DD format.
+         */
+        public fun azure(resourceName: String, deploymentId: String, apiVersion: String): OpenAIHost =
+            OpenAIHost(
+                baseUrl = "https://$resourceName.openai.azure.com/openai/deployments/$deploymentId/",
+                queryParams = mapOf("api-version" to apiVersion),
+            )
     }
 }
+
 
 /** Proxy configuration. */
 public sealed interface ProxyConfig {

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ApiPath.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ApiPath.kt
@@ -1,0 +1,20 @@
+package com.aallam.openai.client.internal.api
+
+/**
+ * Object to handle API paths.
+ */
+internal object ApiPath {
+    const val Translation = "audio/translations"
+    const val Transcription = "audio/transcriptions"
+    const val ChatCompletions = "chat/completions"
+    const val Completions = "completions"
+    const val Edits = "edits"
+    const val Embeddings = "embeddings"
+    const val Files = "files"
+    const val FineTunes = "fine-tunes"
+    const val ImagesGeneration = "images/generations"
+    const val ImagesEdits = "images/edits"
+    const val ImagesVariants = "images/variations"
+    const val Models = "models"
+    const val Moderations = "moderations"
+}

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/AudioApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/AudioApi.kt
@@ -25,13 +25,13 @@ internal class AudioApi(val requester: HttpRequester) : Audio {
 
     private suspend fun transcriptionAsJson(request: TranscriptionRequest): Transcription {
         return requester.perform {
-            it.submitFormWithBinaryData(url = TranscriptionPathV1, formData = formDataOf(request))
+            it.submitFormWithBinaryData(url = ApiPath.Transcription, formData = formDataOf(request))
         }
     }
 
     private suspend fun transcriptionAsString(request: TranscriptionRequest): Transcription {
         val text = requester.perform<String> {
-            it.submitFormWithBinaryData(url = TranscriptionPathV1, formData = formDataOf(request))
+            it.submitFormWithBinaryData(url = ApiPath.Transcription, formData = formDataOf(request))
         }
         return Transcription(text)
     }
@@ -59,13 +59,13 @@ internal class AudioApi(val requester: HttpRequester) : Audio {
 
     private suspend fun translationAsJson(request: TranslationRequest): Translation {
         return requester.perform {
-            it.submitFormWithBinaryData(url = TranslationPathV1, formData = formDataOf(request))
+            it.submitFormWithBinaryData(url = ApiPath.Translation, formData = formDataOf(request))
         }
     }
 
     private suspend fun translationAsString(request: TranslationRequest): Translation {
         val text = requester.perform<String> {
-            it.submitFormWithBinaryData(url = TranslationPathV1, formData = formDataOf(request))
+            it.submitFormWithBinaryData(url = ApiPath.Translation, formData = formDataOf(request))
         }
         return Translation(text)
     }
@@ -79,10 +79,5 @@ internal class AudioApi(val requester: HttpRequester) : Audio {
         request.prompt?.let { prompt -> append(key = "prompt", value = prompt) }
         request.responseFormat?.let { append(key = "response_format", value = it) }
         request.temperature?.let { append(key = "temperature", value = it) }
-    }
-
-    companion object {
-        private const val TranslationPathV1 = "v1/audio/translations"
-        private const val TranscriptionPathV1 = "v1/audio/transcriptions"
     }
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ChatApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ChatApi.kt
@@ -18,7 +18,7 @@ internal class ChatApi(private val requester: HttpRequester) : Chat {
     override suspend fun chatCompletion(request: ChatCompletionRequest): ChatCompletion {
         return requester.perform {
             it.post {
-                url(path = ChatCompletionsPathV1)
+                url(path = ApiPath.ChatCompletions)
                 setBody(request)
                 contentType(ContentType.Application.Json)
             }.body()
@@ -28,7 +28,7 @@ internal class ChatApi(private val requester: HttpRequester) : Chat {
     override fun chatCompletions(request: ChatCompletionRequest): Flow<ChatCompletionChunk> {
         val builder = HttpRequestBuilder().apply {
             method = HttpMethod.Post
-            url(path = ChatCompletionsPathV1)
+            url(path = ApiPath.ChatCompletions)
             setBody(streamRequestOf(request))
             contentType(ContentType.Application.Json)
             accept(ContentType.Text.EventStream)
@@ -40,9 +40,5 @@ internal class ChatApi(private val requester: HttpRequester) : Chat {
         return flow {
             requester.perform(builder) { response -> streamEventsFrom(response) }
         }
-    }
-
-    companion object {
-        private const val ChatCompletionsPathV1 = "v1/chat/completions"
     }
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/CompletionsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/CompletionsApi.kt
@@ -11,7 +11,6 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.util.*
-import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -23,7 +22,7 @@ internal class CompletionsApi(private val requester: HttpRequester) : Completion
     override suspend fun completion(request: CompletionRequest): TextCompletion {
         return requester.perform {
             it.post {
-                url(path = CompletionsPathV1)
+                url(path = ApiPath.Completions)
                 setBody(request)
                 contentType(ContentType.Application.Json)
             }.body()
@@ -34,7 +33,7 @@ internal class CompletionsApi(private val requester: HttpRequester) : Completion
     override fun completions(request: CompletionRequest): Flow<TextCompletion> {
         val builder = HttpRequestBuilder().apply {
             method = HttpMethod.Post
-            url(path = CompletionsPathV1)
+            url(path = ApiPath.Completions)
             setBody(request.toStreamRequest())
             contentType(ContentType.Application.Json)
             accept(ContentType.Text.EventStream)
@@ -46,11 +45,5 @@ internal class CompletionsApi(private val requester: HttpRequester) : Completion
         return flow {
             requester.perform(builder) { response -> streamEventsFrom(response) }
         }
-    }
-
-    companion object {
-        private const val CompletionsPathV1 = "v1/completions"
-        private const val StreamPrefix = "data:"
-        private const val StreamEndToken = "$StreamPrefix [DONE]"
     }
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/EditsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/EditsApi.kt
@@ -20,14 +20,10 @@ internal class EditsApi(private val requester: HttpRequester) : Edits {
     override suspend fun edit(request: EditsRequest): Edit {
         return requester.perform {
             it.post {
-                url(path = EditsPathV1)
+                url(path = ApiPath.Edits)
                 setBody(request)
                 contentType(ContentType.Application.Json)
             }.body()
         }
-    }
-
-    companion object {
-        private const val EditsPathV1 = "v1/edits"
     }
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/EmbeddingsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/EmbeddingsApi.kt
@@ -20,14 +20,10 @@ internal class EmbeddingsApi(private val requester: HttpRequester) : Embeddings 
     override suspend fun embeddings(request: EmbeddingRequest): EmbeddingResponse {
         return requester.perform {
             it.post {
-                url(path = EmbeddingsPathV1)
+                url(path = ApiPath.Embeddings)
                 setBody(request)
                 contentType(ContentType.Application.Json)
             }.body()
         }
-    }
-
-    companion object {
-        private const val EmbeddingsPathV1 = "v1/embeddings"
     }
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/FilesApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/FilesApi.kt
@@ -23,7 +23,7 @@ internal class FilesApi(private val requester: HttpRequester) : Files {
 
     override suspend fun file(request: FileUpload): File {
         return requester.perform {
-            it.submitFormWithBinaryData(url = FilesPath, formData = formData {
+            it.submitFormWithBinaryData(url = ApiPath.Files, formData = formData {
                 appendFileSource("file", request.file)
                 append(key = "purpose", value = request.purpose.raw)
             })
@@ -31,13 +31,13 @@ internal class FilesApi(private val requester: HttpRequester) : Files {
     }
 
     override suspend fun files(): List<File> {
-        return requester.perform<ListResponse<File>> { it.get { url(path = FilesPath) } }.data
+        return requester.perform<ListResponse<File>> { it.get { url(path = ApiPath.Files) } }.data
     }
 
     override suspend fun file(fileId: FileId): File? {
         try {
             return requester.perform<HttpResponse> {
-                it.get { url(path = "$FilesPath/${fileId.id}") }
+                it.get { url(path = "${ApiPath.Files}/${fileId.id}") }
             }.body()
         } catch (e: OpenAIAPIException) {
             if (e.statusCode == HttpStatusCode.NotFound.value) return null
@@ -48,7 +48,7 @@ internal class FilesApi(private val requester: HttpRequester) : Files {
     override suspend fun delete(fileId: FileId): Boolean {
         val response = requester.perform<HttpResponse> {
             it.delete {
-                url(path = "$FilesPath/${fileId.id}")
+                url(path = "${ApiPath.Files}/${fileId.id}")
             }
         }
 
@@ -60,11 +60,8 @@ internal class FilesApi(private val requester: HttpRequester) : Files {
 
     override suspend fun download(fileId: FileId): ByteArray {
         return requester.perform {
-            it.get { url(path = "$FilesPath/${fileId.id}/content") }
+            it.get { url(path = "${ApiPath.Files}/${fileId.id}/content") }
         }
     }
 
-    companion object {
-        private const val FilesPath = "v1/files"
-    }
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ImagesApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ImagesApi.kt
@@ -17,7 +17,7 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
     override suspend fun imageURL(creation: ImageCreation): List<ImageURL> {
         return requester.perform<ListResponse<ImageURL>> {
             it.post {
-                url(path = ImagesGenerationV1)
+                url(path = ApiPath.ImagesGeneration)
                 setBody(creation.toURLRequest())
                 contentType(ContentType.Application.Json)
             }
@@ -27,7 +27,7 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
     override suspend fun imageJSON(creation: ImageCreation): List<ImageJSON> {
         return requester.perform<ListResponse<ImageJSON>> {
             it.post {
-                url(path = ImagesGenerationV1)
+                url(path = ApiPath.ImagesGeneration)
                 setBody(creation.toJSONRequest())
                 contentType(ContentType.Application.Json)
             }
@@ -36,14 +36,17 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
 
     override suspend fun imageURL(edit: ImageEdit): List<ImageURL> {
         return requester.perform<ListResponse<ImageURL>> {
-            it.submitFormWithBinaryData(url = ImagesEditsV1, formData = imageEditRequest(edit, ImageResponseFormat.url))
+            it.submitFormWithBinaryData(
+                url = ApiPath.ImagesEdits,
+                formData = imageEditRequest(edit, ImageResponseFormat.url)
+            )
         }.data
     }
 
     override suspend fun imageJSON(edit: ImageEdit): List<ImageJSON> {
         return requester.perform<ListResponse<ImageJSON>> {
             it.submitFormWithBinaryData(
-                url = ImagesEditsV1, formData = imageEditRequest(edit, ImageResponseFormat.base64Json)
+                url = ApiPath.ImagesEdits, formData = imageEditRequest(edit, ImageResponseFormat.base64Json)
             )
         }.data
     }
@@ -64,7 +67,7 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
     override suspend fun imageURL(variation: ImageVariation): List<ImageURL> {
         return requester.perform<ListResponse<ImageURL>> {
             it.submitFormWithBinaryData(
-                url = ImagesVariantsV1, formData = imageVariantRequest(variation, ImageResponseFormat.url)
+                url = ApiPath.ImagesVariants, formData = imageVariantRequest(variation, ImageResponseFormat.url)
             )
         }.data
     }
@@ -72,7 +75,7 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
     override suspend fun imageJSON(variation: ImageVariation): List<ImageJSON> {
         return requester.perform<ListResponse<ImageJSON>> {
             it.submitFormWithBinaryData(
-                url = ImagesVariantsV1, formData = imageVariantRequest(variation, ImageResponseFormat.base64Json)
+                url = ApiPath.ImagesVariants, formData = imageVariantRequest(variation, ImageResponseFormat.base64Json)
             )
         }.data
     }
@@ -98,11 +101,4 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
     private fun ImageCreation.toURLRequest() = ImageCreationRequest(
         prompt = prompt, n = n, size = size, user = user, responseFormat = ImageResponseFormat.url,
     )
-
-
-    companion object {
-        private const val ImagesGenerationV1 = "v1/images/generations"
-        private const val ImagesEditsV1 = "v1/images/edits"
-        private const val ImagesVariantsV1 = "v1/images/variations"
-    }
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ModelsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ModelsApi.kt
@@ -6,10 +6,8 @@ import com.aallam.openai.api.model.ModelId
 import com.aallam.openai.client.Models
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
-import io.ktor.client.request.get
-import io.ktor.client.request.url
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
+import io.ktor.client.request.*
+import io.ktor.http.*
 
 /**
  * Implementation of [Models] API.
@@ -18,20 +16,16 @@ internal class ModelsApi(private val requester: HttpRequester) : Models {
 
     override suspend fun models(): List<Model> {
         return requester.perform<ListResponse<Model>> {
-            it.get { url(path = ModelsPathV1) }
+            it.get { url(path = ApiPath.Models) }
         }.data
     }
 
     override suspend fun model(modelId: ModelId): Model {
         return requester.perform {
             it.get {
-                url(path = "$ModelsPathV1/${modelId.id}")
+                url(path = "${ApiPath.Models}/${modelId.id}")
                 contentType(ContentType.Application.Json)
             }
         }
-    }
-
-    companion object {
-        internal const val ModelsPathV1 = "v1/models"
     }
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ModerationsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ModerationsApi.kt
@@ -5,12 +5,9 @@ import com.aallam.openai.api.moderation.TextModeration
 import com.aallam.openai.client.Moderations
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
-import io.ktor.client.call.body
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.client.request.url
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
 
 /**
  * Implementation of [Moderations].
@@ -20,14 +17,10 @@ internal class ModerationsApi(private val requester: HttpRequester) : Moderation
     override suspend fun moderations(request: ModerationRequest): TextModeration {
         return requester.perform {
             it.post {
-                url(path = ModerationsPathV1)
+                url(path = ApiPath.Moderations)
                 setBody(request)
                 contentType(ContentType.Application.Json)
             }.body()
         }
-    }
-
-    companion object {
-        const val ModerationsPathV1 = "v1/moderations"
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #195

## Describe your change

- [x] Support of `OpenAIHost` with a base path and removes hard coded `v1` from API paths.
- [x] Add host builder for Azure:`OpenAIHost.azure(resourceName, deploymentId, apiVersion)`