### PR TITLE
fix: function mode serializer

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/FunctionMode.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/FunctionMode.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.jvm.JvmInline
 
 /**
@@ -62,7 +63,7 @@ internal object FunctionModeSerializer : KSerializer<FunctionMode> {
         require(decoder is JsonDecoder) { "This decoder is not a JsonDecoder. Cannot deserialize `FunctionCall`" }
         return when (val json = decoder.decodeJsonElement()) {
             is JsonPrimitive -> Default(json.content)
-            is JsonObject -> Named.serializer().deserialize(decoder)
+            is JsonObject -> json["name"]?.jsonPrimitive?.content?.let(FunctionMode::Named) ?: error("Missing 'name'")
             else -> throw UnsupportedOperationException("Cannot deserialize FunctionMode. Unsupported JSON element.")
         }
     }

--- a/openai-core/src/commonTest/kotlin/com.aallam.openai.api/chat/TestFunctionMode.kt
+++ b/openai-core/src/commonTest/kotlin/com.aallam.openai.api/chat/TestFunctionMode.kt
@@ -1,0 +1,23 @@
+package com.aallam.openai.api.chat
+
+import com.aallam.openai.api.BetaOpenAI
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(BetaOpenAI::class)
+class TestFunctionMode {
+
+    @Test
+    fun serialize() {
+        listOf(
+            FunctionMode.Auto,
+            FunctionMode.None,
+            FunctionMode.Named("someFunctionName")
+        ).forEach { functionMode ->
+            val jsonString = Json.encodeToString(FunctionMode.serializer(), functionMode)
+            val decoded = Json.decodeFromString(FunctionMode.serializer(), jsonString)
+            assertEquals(functionMode, decoded)
+        }
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | n/a

## Describe your change

Update `FunctionModeSerializer` to read `name` from the decoded `JsonObject`.

## What problem is this fixing?

`FunctionModeSerializer`, when processing `FunctionMode.Named`, attempts to decode twice, which results in an exception. See included test, `TestFunctionMode`.