### PR TITLE
update: headers info with functions (Chat + Audio + Completion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 3.3.2
+> Published 7 Jul 2023
+
+### Added
+- **Chat**: function for response with headers info
+- **Whisper**: function for response with headers info
+- Update sample module to test new features
+
 # 3.3.1
 > Published 24 Jun 2023
 

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Audio.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Audio.kt
@@ -16,7 +16,7 @@ public interface Audio {
     public suspend fun transcription(request: TranscriptionRequest): Transcription
 
     @BetaOpenAI
-    public suspend fun transcriptionWithHeaders(request: TranscriptionRequest): Pair<Transcription, Headers>
+    public suspend fun transcriptionHeaders(request: TranscriptionRequest): Pair<Transcription, Headers>
 
     /**
      * Translates audio into English.

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Audio.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Audio.kt
@@ -2,6 +2,7 @@ package com.aallam.openai.client
 
 import com.aallam.openai.api.BetaOpenAI
 import com.aallam.openai.api.audio.*
+import io.ktor.http.*
 
 /**
  * Learn how to turn audio into text.
@@ -13,6 +14,9 @@ public interface Audio {
      */
     @BetaOpenAI
     public suspend fun transcription(request: TranscriptionRequest): Transcription
+
+    @BetaOpenAI
+    public suspend fun transcriptionWithHeaders(request: TranscriptionRequest): Pair<Transcription, Headers>
 
     /**
      * Translates audio into English.

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Audio.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Audio.kt
@@ -23,4 +23,7 @@ public interface Audio {
      */
     @BetaOpenAI
     public suspend fun translation(request: TranslationRequest): Translation
+
+    @BetaOpenAI
+    public suspend fun translationHeaders(request: TranslationRequest): Pair<Translation, Headers>
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Chat.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Chat.kt
@@ -19,7 +19,7 @@ public interface Chat {
     public suspend fun chatCompletion(request: ChatCompletionRequest): ChatCompletion
 
     @BetaOpenAI
-    public suspend fun chatCompletionWithHeaders(request: ChatCompletionRequest): Pair<ChatCompletion, Headers>
+    public suspend fun chatCompletionHeaders(request: ChatCompletionRequest): Pair<ChatCompletion, Headers>
 
     /**
      * Stream variant of [chatCompletion].

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Chat.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Chat.kt
@@ -4,6 +4,7 @@ import com.aallam.openai.api.BetaOpenAI
 import com.aallam.openai.api.chat.ChatCompletion
 import com.aallam.openai.api.chat.ChatCompletionChunk
 import com.aallam.openai.api.chat.ChatCompletionRequest
+import io.ktor.http.*
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -16,6 +17,9 @@ public interface Chat {
      */
     @BetaOpenAI
     public suspend fun chatCompletion(request: ChatCompletionRequest): ChatCompletion
+
+    @BetaOpenAI
+    public suspend fun chatCompletionWithHeaders(request: ChatCompletionRequest): Pair<ChatCompletion, Headers>
 
     /**
      * Stream variant of [chatCompletion].

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Completions.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Completions.kt
@@ -2,6 +2,7 @@ package com.aallam.openai.client
 
 import com.aallam.openai.api.completion.CompletionRequest
 import com.aallam.openai.api.completion.TextCompletion
+import io.ktor.http.*
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -15,6 +16,8 @@ public interface Completions {
      * and can also return the probabilities of alternative tokens at each position if requested.
      */
     public suspend fun completion(request: CompletionRequest): TextCompletion
+
+    public suspend fun completionHeaders(request: CompletionRequest): Pair<TextCompletion, Headers>
 
     /**
      * Stream variant of [completion].

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/AudioApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/AudioApi.kt
@@ -80,6 +80,14 @@ internal class AudioApi(val requester: HttpRequester) : Audio {
         }
     }
 
+    @BetaOpenAI
+    override suspend fun translationHeaders(request: TranslationRequest): Pair<Translation, Headers> {
+        return when (request.responseFormat) {
+            "json", "verbose_json", null -> translationAsJsonHeaders(request)
+            else -> translationAsStringHeaders(request)
+        }
+    }
+
     private suspend fun translationAsJson(request: TranslationRequest): Translation {
         return requester.perform {
             it.submitFormWithBinaryData(url = ApiPath.Translation, formData = formDataOf(request))
@@ -91,6 +99,19 @@ internal class AudioApi(val requester: HttpRequester) : Audio {
             it.submitFormWithBinaryData(url = ApiPath.Translation, formData = formDataOf(request))
         }
         return Translation(text)
+    }
+
+    private suspend fun translationAsJsonHeaders(request: TranslationRequest): Pair<Translation, Headers> {
+        return requester.performHeaders {
+            it.submitFormWithBinaryData(url = ApiPath.Translation, formData = formDataOf(request))
+        }
+    }
+
+    private suspend fun translationAsStringHeaders(request: TranslationRequest): Pair<Translation, Headers> {
+        val text = requester.performHeaders<String> {
+            it.submitFormWithBinaryData(url = ApiPath.Translation, formData = formDataOf(request))
+        }
+        return Translation(text.first) to text.second
     }
 
     /**

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ChatApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ChatApi.kt
@@ -10,6 +10,7 @@ import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
 import io.ktor.client.call.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -23,6 +24,17 @@ internal class ChatApi(private val requester: HttpRequester) : Chat {
                 contentType(ContentType.Application.Json)
             }.body()
         }
+    }
+
+    override suspend fun chatCompletionWithHeaders(request: ChatCompletionRequest): Pair<ChatCompletion, Headers> {
+        val httpResponse: HttpResponse = requester.perform {
+            it.post {
+                url(path = ApiPath.ChatCompletions)
+                setBody(request)
+                contentType(ContentType.Application.Json)
+            }.body()
+        }
+        return httpResponse.body<ChatCompletion>() to httpResponse.headers
     }
 
     override fun chatCompletions(request: ChatCompletionRequest): Flow<ChatCompletionChunk> {

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ChatApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ChatApi.kt
@@ -8,9 +8,9 @@ import com.aallam.openai.client.internal.extension.streamEventsFrom
 import com.aallam.openai.client.internal.extension.streamRequestOf
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
+import com.aallam.openai.client.internal.http.performHeaders
 import io.ktor.client.call.*
 import io.ktor.client.request.*
-import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -26,15 +26,14 @@ internal class ChatApi(private val requester: HttpRequester) : Chat {
         }
     }
 
-    override suspend fun chatCompletionWithHeaders(request: ChatCompletionRequest): Pair<ChatCompletion, Headers> {
-        val httpResponse: HttpResponse = requester.perform {
+    override suspend fun chatCompletionHeaders(request: ChatCompletionRequest): Pair<ChatCompletion, Headers> {
+        return requester.performHeaders {
             it.post {
                 url(path = ApiPath.ChatCompletions)
                 setBody(request)
                 contentType(ContentType.Application.Json)
             }.body()
         }
-        return httpResponse.body<ChatCompletion>() to httpResponse.headers
     }
 
     override fun chatCompletions(request: ChatCompletionRequest): Flow<ChatCompletionChunk> {

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/CompletionsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/CompletionsApi.kt
@@ -7,6 +7,7 @@ import com.aallam.openai.client.internal.extension.streamEventsFrom
 import com.aallam.openai.client.internal.extension.toStreamRequest
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
+import com.aallam.openai.client.internal.http.performHeaders
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
@@ -21,6 +22,16 @@ internal class CompletionsApi(private val requester: HttpRequester) : Completion
 
     override suspend fun completion(request: CompletionRequest): TextCompletion {
         return requester.perform {
+            it.post {
+                url(path = ApiPath.Completions)
+                setBody(request)
+                contentType(ContentType.Application.Json)
+            }.body()
+        }
+    }
+
+    override suspend fun completionHeaders(request: CompletionRequest): Pair<TextCompletion, Headers> {
+        return requester.performHeaders {
             it.post {
                 url(path = ApiPath.Completions)
                 setBody(request)

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpRequester.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpRequester.kt
@@ -4,6 +4,7 @@ import com.aallam.openai.client.Closeable
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import io.ktor.http.*
 import io.ktor.util.reflect.*
 
 /**
@@ -17,6 +18,12 @@ internal interface HttpRequester : Closeable {
     suspend fun <T : Any> perform(info: TypeInfo, block: suspend (HttpClient) -> HttpResponse): T
 
     /**
+     * Perform an HTTP request and get a result with headers.
+     */
+    suspend fun <T : Any> performHeaders(info: TypeInfo, block: suspend (HttpClient) -> HttpResponse): Pair<T, Headers>
+
+
+    /**
      * Perform an HTTP request and get a result.
      *
      * Note: [HttpResponse] instance shouldn't be passed outside of [block].
@@ -25,6 +32,7 @@ internal interface HttpRequester : Closeable {
         builder: HttpRequestBuilder,
         block: suspend (response: HttpResponse) -> T
     )
+
 }
 
 /**
@@ -32,4 +40,11 @@ internal interface HttpRequester : Closeable {
  */
 internal suspend inline fun <reified T> HttpRequester.perform(noinline block: suspend (HttpClient) -> HttpResponse): T {
     return perform(typeInfo<T>(), block)
+}
+
+/**
+ * Perform an HTTP request and get a result with headers
+ */
+internal suspend inline fun <reified T> HttpRequester.performHeaders(noinline block: suspend (HttpClient) -> HttpResponse): Pair<T, Headers> {
+    return performHeaders(typeInfo<T>(), block)
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpTransport.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpTransport.kt
@@ -7,6 +7,7 @@ import io.ktor.client.network.sockets.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import io.ktor.http.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.errors.*
 import kotlinx.coroutines.CancellationException
@@ -19,6 +20,20 @@ internal class HttpTransport(private val httpClient: HttpClient) : HttpRequester
         try {
             val response = block(httpClient)
             return response.body(info)
+        } catch (e: Exception) {
+            throw handleException(e)
+        }
+    }
+
+    override suspend fun <T : Any> performHeaders(
+        info: TypeInfo,
+        block: suspend (HttpClient) -> HttpResponse
+    ): Pair<T, Headers> {
+        try {
+            val response = block(httpClient)
+            val responseBody: T = response.body(info)
+            val responseHeaders = response.headers
+            return responseBody to responseHeaders
         } catch (e: Exception) {
             throw handleException(e)
         }

--- a/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/App.kt
+++ b/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/App.kt
@@ -18,8 +18,10 @@ fun main() = runBlocking {
         println("4 - Moderations")
         println("5 - Images")
         println("6 - Chat")
+        println("61 - Chat with Headers")
         println("7 - Chat (w/ Function)")
         println("8 - Whisper")
+        println("81 - Whisper with Headers")
         println("0 - Quit")
 
         when (readlnOrNull()?.toIntOrNull()) {
@@ -29,8 +31,10 @@ fun main() = runBlocking {
             4 -> moderations(openAI)
             5 -> images(openAI)
             6 -> chat(openAI)
+            61 -> chatWithHeaders(openAI)
             7 -> chatFunctionCall(openAI)
             8 -> whisper(openAI)
+            81 -> whisperWithHeaders(openAI)
             0 -> {
                 println("Exiting...")
                 return@runBlocking

--- a/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/App.kt
+++ b/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/App.kt
@@ -14,6 +14,7 @@ fun main() = runBlocking {
         println("Select an option:")
         println("1 - Engines")
         println("2 - Completion")
+        println("22 - Completion With Headers")
         println("3 - Files")
         println("4 - Moderations")
         println("5 - Images")
@@ -27,6 +28,7 @@ fun main() = runBlocking {
         when (readlnOrNull()?.toIntOrNull()) {
             1 -> engines(openAI)
             2 -> completion(openAI)
+            22 -> completionHeaders(openAI)
             3 -> files(openAI)
             4 -> moderations(openAI)
             5 -> images(openAI)

--- a/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/Chat.kt
+++ b/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/Chat.kt
@@ -6,7 +6,6 @@ import com.aallam.openai.api.chat.ChatMessage
 import com.aallam.openai.api.chat.ChatRole
 import com.aallam.openai.api.model.ModelId
 import com.aallam.openai.client.OpenAI
-import io.ktor.util.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
@@ -54,10 +53,10 @@ suspend fun chatWithHeaders(openAI: OpenAI) {
             )
         )
     )
-    val response = openAI.chatCompletionWithHeaders(chatCompletionRequest)
+    val response = openAI.chatCompletionHeaders(chatCompletionRequest)
 
     val text = response.first.choices.firstOrNull()?.message?.content ?: ""
     val headers = response.second
 
-    println("text: $text. headers: ${headers.toMap()}")
+    println("text: $text. headers: $headers")
 }

--- a/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/Chat.kt
+++ b/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/Chat.kt
@@ -6,6 +6,7 @@ import com.aallam.openai.api.chat.ChatMessage
 import com.aallam.openai.api.chat.ChatRole
 import com.aallam.openai.api.model.ModelId
 import com.aallam.openai.client.OpenAI
+import io.ktor.util.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
@@ -35,4 +36,28 @@ suspend fun CoroutineScope.chat(openAI: OpenAI) {
         .onCompletion { println() }
         .launchIn(this)
         .join()
+}
+
+@OptIn(BetaOpenAI::class)
+suspend fun chatWithHeaders(openAI: OpenAI) {
+    println("\n> Create chat completions with headers...")
+    val chatCompletionRequest = ChatCompletionRequest(
+        model = ModelId("gpt-3.5-turbo"),
+        messages = listOf(
+            ChatMessage(
+                role = ChatRole.System,
+                content = "You are a helpful assistant that translates English to French."
+            ),
+            ChatMessage(
+                role = ChatRole.User,
+                content = "Translate the following English text to French: “OpenAI is awesome!”"
+            )
+        )
+    )
+    val response = openAI.chatCompletionWithHeaders(chatCompletionRequest)
+
+    val text = response.first.choices.firstOrNull()?.message?.content ?: ""
+    val headers = response.second
+
+    println("text: $text. headers: ${headers.toMap()}")
 }

--- a/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/Completion.kt
+++ b/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/Completion.kt
@@ -23,3 +23,16 @@ suspend fun CoroutineScope.completion(openAI: OpenAI) {
         .launchIn(this)
         .join()
 }
+
+suspend fun completionHeaders(openAI: OpenAI) {
+    println("\n>️ Creating completion...")
+    val completionRequest = CompletionRequest(
+        model = ModelId("text-ada-001"),
+        prompt = "Somebody once told me the world is gonna roll me"
+    )
+
+    val result = openAI.completionHeaders(completionRequest)
+    val text = result.first.choices.joinToString("") { it.text }
+    val headers = result.second
+    println("Completion result: $text. Headers: $headers")
+}

--- a/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/Whisper.kt
+++ b/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/Whisper.kt
@@ -6,6 +6,7 @@ import com.aallam.openai.api.audio.TranslationRequest
 import com.aallam.openai.api.file.FileSource
 import com.aallam.openai.api.model.ModelId
 import com.aallam.openai.client.OpenAI
+import io.ktor.util.*
 import okio.FileSystem
 import okio.Path.Companion.toPath
 
@@ -26,4 +27,15 @@ suspend fun whisper(openAI: OpenAI) {
     )
     val translation = openAI.translation(translationRequest)
     println(translation)
+}
+
+@OptIn(BetaOpenAI::class)
+suspend fun whisperWithHeaders(openAI: OpenAI) {
+    println("\n>️ Create transcription...")
+    val transcriptionRequest = TranscriptionRequest(
+        audio = FileSource(path = "micro-machines.wav".toPath(), fileSystem = FileSystem.RESOURCES),
+        model = ModelId("whisper-1"),
+    )
+    val transcription = openAI.transcriptionWithHeaders(transcriptionRequest)
+    println("result: ${transcription.first.text}. headers: ${transcription.second.toMap()}")
 }

--- a/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/Whisper.kt
+++ b/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/Whisper.kt
@@ -31,11 +31,19 @@ suspend fun whisper(openAI: OpenAI) {
 
 @OptIn(BetaOpenAI::class)
 suspend fun whisperWithHeaders(openAI: OpenAI) {
-    println("\n>️ Create transcription...")
+    println("\n>️ Create transcription with headers...")
     val transcriptionRequest = TranscriptionRequest(
         audio = FileSource(path = "micro-machines.wav".toPath(), fileSystem = FileSystem.RESOURCES),
         model = ModelId("whisper-1"),
     )
     val transcription = openAI.transcriptionHeaders(transcriptionRequest)
-    println("result: ${transcription.first.text}. headers: ${transcription.second.toMap()}")
+    println("Transcription result: ${transcription.first.text}. headers: ${transcription.second.toMap()}")
+
+    println("\n>️ Create translation with headers...")
+    val translationRequest = TranslationRequest(
+        audio = FileSource(path = "multilingual.wav".toPath(), fileSystem = FileSystem.RESOURCES),
+        model = ModelId("whisper-1"),
+    )
+    val translation = openAI.translationHeaders(translationRequest)
+    println(translation)
 }

--- a/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/Whisper.kt
+++ b/sample/jvm/src/main/kotlin/com/aallam/openai/sample/jvm/Whisper.kt
@@ -36,6 +36,6 @@ suspend fun whisperWithHeaders(openAI: OpenAI) {
         audio = FileSource(path = "micro-machines.wav".toPath(), fileSystem = FileSystem.RESOURCES),
         model = ModelId("whisper-1"),
     )
-    val transcription = openAI.transcriptionWithHeaders(transcriptionRequest)
+    val transcription = openAI.transcriptionHeaders(transcriptionRequest)
     println("result: ${transcription.first.text}. headers: ${transcription.second.toMap()}")
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | Fix #206 

## Describe your change

Added two new methods to Chat and Audio, so now two new functions available for getting response with headers. Also updated sample to test new features

## What problem is this fixing?

No headers info was available with default response
