### PR TITLE
Add response_format argument to ChatCompletionRequest

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionRequest.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionRequest.kt
@@ -1,6 +1,5 @@
 package com.aallam.openai.api.chat
 
-import com.aallam.openai.api.BetaOpenAI
 import com.aallam.openai.api.OpenAIDsl
 import com.aallam.openai.api.model.ModelId
 import kotlinx.serialization.SerialName
@@ -99,6 +98,20 @@ public class ChatCompletionRequest(
      * [FunctionMode.Auto] is the default if functions are present.
      */
     @SerialName("function_call") public val functionCall: FunctionMode? = null,
+
+    /**
+     * Specify the format that the model must output.
+     *
+     * Setting to [ChatResponseFormat.JSON] enables JSON mode, which guarantees the message the model generates is valid
+     * JSON. The default is [ChatResponseFormat.TEXT], which is plain text.
+     *
+     * Important: when using JSON mode you must still instruct the model to produce JSON yourself via some conversation
+     * message, for example via your system message. If you don't do this, the model may generate an unending stream of
+     * whitespace until the generation reaches the token limit, which may take a lot of time and give the appearance of
+     * a "stuck" request. Also note that the message content may be partial (i.e. cut off) if finish_reason="length",
+     * which indicates the generation exceeded max_tokens or the conversation exceeded the max context length.
+     */
+    @SerialName("response_format") public val responseFormat: ChatResponseFormat? = null,
 )
 
 /**

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatResponseFormat.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatResponseFormat.kt
@@ -1,0 +1,48 @@
+package com.aallam.openai.api.chat
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+@Serializable(with = ChatResponseFormatSerializer::class)
+public enum class ChatResponseFormat(
+    internal val value: String,
+) {
+    JSON("json_object"),
+    TEXT("text"),
+}
+
+internal object ChatResponseFormatSerializer : KSerializer<ChatResponseFormat> {
+    private const val TYPE_PARAM = "type"
+
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
+        serialName = "ChatResponseFormat",
+        PrimitiveKind.STRING,
+    )
+
+    override fun serialize(encoder: Encoder, value: ChatResponseFormat) {
+        val json = JsonObject(mapOf(TYPE_PARAM to JsonPrimitive(value.value)))
+        encoder.encodeSerializableValue(JsonElement.serializer(), json)
+    }
+
+    override fun deserialize(decoder: Decoder): ChatResponseFormat =
+        (decoder.decodeSerializableValue(JsonElement.serializer()) as? JsonObject)?.let { json ->
+            json[TYPE_PARAM]?.jsonPrimitive?.contentOrNull?.let { type ->
+                when (type) {
+                    ChatResponseFormat.JSON.value -> ChatResponseFormat.JSON
+                    ChatResponseFormat.TEXT.value -> ChatResponseFormat.TEXT
+                    else -> throw SerializationException("Unknown ChatResponseFormat type: $type")
+                }
+            }
+        } ?: throw SerializationException("ChatResponseFormat deserialization failed")
+}

--- a/openai-core/src/commonTest/kotlin/com.aallam.openai.api/chat/ChatResponseFormatTest.kt
+++ b/openai-core/src/commonTest/kotlin/com.aallam.openai.api/chat/ChatResponseFormatTest.kt
@@ -1,0 +1,21 @@
+package com.aallam.openai.api.chat
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ChatResponseFormatTest {
+
+    @Test
+    fun serialize() {
+        listOf(
+            ChatResponseFormat.JSON,
+            ChatResponseFormat.TEXT,
+        ).forEach {
+            val jsonString = Json.encodeToString(ChatResponseFormat.serializer(), it)
+            assertEquals(jsonString, """{"type":"${it.value}"}""")
+            val decoded = Json.decodeFromString(ChatResponseFormat.serializer(), jsonString)
+            assertEquals(it, decoded)
+        }
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | Fix #254

## Describe your change

Adds the `response_format` argument to `ChatCompletionRequest`

## What problem is this fixing?

Gives us JSON output coercion