### PR TITLE
feat(images): add support for model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 3.5.2
-> Published 8 Nov 2023
+> Unreleased
 
 ### Added
 - **Images**: Support for model selection for `ImageCreation`, `ImageEdit` and `ImageVariations`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.5.2
+> Published 8 Nov 2023
+
+### Added
+- **Images**: Support for model selection for `ImageCreation`, `ImageEdit` and `ImageVariations`
+
 # 3.5.1
 > Published 05 Nov 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-# 3.5.2
-> Unreleased
+# Unreleased
 
 ### Added
 - **Images**: Support for model selection for `ImageCreation`, `ImageEdit` and `ImageVariations`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.aallam.openai:openai-client:3.5.1"
+    implementation "com.aallam.openai:openai-client:3.5.2"
 }
 ```
 
@@ -30,7 +30,7 @@ Alternatively, you can use [openai-client-bom](/openai-client-bom)  by adding th
 ```groovy
 dependencies {
     // import Kotlin API client BOM
-    implementation platform('com.aallam.openai:openai-client-bom:3.5.1')
+    implementation platform('com.aallam.openai:openai-client-bom:3.5.2')
 
     // define dependencies without versions
     implementation 'com.aallam.openai:openai-client'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.aallam.openai:openai-client:3.5.2"
+    implementation "com.aallam.openai:openai-client:3.5.1"
 }
 ```
 
@@ -30,7 +30,7 @@ Alternatively, you can use [openai-client-bom](/openai-client-bom)  by adding th
 ```groovy
 dependencies {
     // import Kotlin API client BOM
-    implementation platform('com.aallam.openai:openai-client-bom:3.5.2')
+    implementation platform('com.aallam.openai:openai-client-bom:3.5.1')
 
     // define dependencies without versions
     implementation 'com.aallam.openai:openai-client'

--- a/guides/GettingStarted.md
+++ b/guides/GettingStarted.md
@@ -115,6 +115,7 @@ Creates an image given a prompt.
 val images = openAI.imageURL( // or openAI.imageJSON
     creation = ImageCreation(
         prompt = "A cute baby sea otter",
+        model = ModelId("dall-e-3"),
         n = 2,
         size = ImageSize.is1024x1024
     )
@@ -129,6 +130,7 @@ Creates an edited or extended image given an original image and a prompt.
 val images = openAI.imageURL( // or openAI.imageJSON
     edit = ImageEdit(
         image = FileSource(name = "<filename>", source = imageSource),
+        model = ModelId("dall-e-2"),
         mask = FileSource(name = "<filename>", source = maskSource),
         prompt = "a sunlit indoor lounge area with a pool containing a flamingo",
         n = 1,
@@ -145,6 +147,7 @@ Creates a variation of a given image.
 val images = openAI.imageURL( // or openAI.imageJSON
     variation = ImageVariation(
         image = FileSource(name = "<filename>", source = imageSource),
+        model = ModelId("dall-e-3"),
         n = 1,
         size = ImageSize.is1024x1024
     )

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ImagesApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ImagesApi.kt
@@ -59,7 +59,7 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
         appendFileSource("mask", edit.mask)
         append(key = "prompt", value = edit.prompt)
         append(key = "response_format", value = responseFormat.format)
-        edit.model?.let { model -> append(key = "model", value = model) }
+        edit.model?.let { model -> append(key = "model", value = model.id) }
         edit.n?.let { n -> append(key = "n", value = n) }
         edit.size?.let { dim -> append(key = "size", value = dim.size) }
         edit.user?.let { user -> append(key = "user", value = user) }
@@ -87,20 +87,19 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
     private fun imageVariantRequest(edit: ImageVariation, responseFormat: ImageResponseFormat) = formData {
         appendFileSource("image", edit.image)
         append(key = "response_format", value = responseFormat.format)
-        edit.model?.let { model -> append(key = "model", value = model) }
+        edit.model?.let { model -> append(key = "model", value = model.id) }
         edit.n?.let { n -> append(key = "n", value = n) }
         edit.size?.let { dim -> append(key = "size", value = dim.size) }
         edit.user?.let { user -> append(key = "user", value = user) }
-
     }
 
     /** Convert [ImageCreation] instance to base64 JSON request */
     private fun ImageCreation.toJSONRequest() = ImageCreationRequest(
-        prompt = prompt, model = model, n = n, size = size, user = user, responseFormat = ImageResponseFormat.base64Json,
+        prompt = prompt, model = model?.id, n = n, size = size, user = user, responseFormat = ImageResponseFormat.base64Json,
     )
 
     /** Convert [ImageCreation] instance to URL request */
     private fun ImageCreation.toURLRequest() = ImageCreationRequest(
-        prompt = prompt, model = model, n = n, size = size, user = user, responseFormat = ImageResponseFormat.url,
+        prompt = prompt, model = model?.id, n = n, size = size, user = user, responseFormat = ImageResponseFormat.url,
     )
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ImagesApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ImagesApi.kt
@@ -59,6 +59,7 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
         appendFileSource("mask", edit.mask)
         append(key = "prompt", value = edit.prompt)
         append(key = "response_format", value = responseFormat.format)
+        edit.model?.let { model -> append(key = "model", value = model) }
         edit.n?.let { n -> append(key = "n", value = n) }
         edit.size?.let { dim -> append(key = "size", value = dim.size) }
         edit.user?.let { user -> append(key = "user", value = user) }
@@ -86,6 +87,7 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
     private fun imageVariantRequest(edit: ImageVariation, responseFormat: ImageResponseFormat) = formData {
         appendFileSource("image", edit.image)
         append(key = "response_format", value = responseFormat.format)
+        edit.model?.let { model -> append(key = "model", value = model) }
         edit.n?.let { n -> append(key = "n", value = n) }
         edit.size?.let { dim -> append(key = "size", value = dim.size) }
         edit.user?.let { user -> append(key = "user", value = user) }
@@ -94,11 +96,11 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
 
     /** Convert [ImageCreation] instance to base64 JSON request */
     private fun ImageCreation.toJSONRequest() = ImageCreationRequest(
-        prompt = prompt, n = n, size = size, user = user, responseFormat = ImageResponseFormat.base64Json,
+        prompt = prompt, model = model, n = n, size = size, user = user, responseFormat = ImageResponseFormat.base64Json,
     )
 
     /** Convert [ImageCreation] instance to URL request */
     private fun ImageCreation.toURLRequest() = ImageCreationRequest(
-        prompt = prompt, n = n, size = size, user = user, responseFormat = ImageResponseFormat.url,
+        prompt = prompt, model = model, n = n, size = size, user = user, responseFormat = ImageResponseFormat.url,
     )
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ImagesApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ImagesApi.kt
@@ -59,10 +59,10 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
         appendFileSource("mask", edit.mask)
         append(key = "prompt", value = edit.prompt)
         append(key = "response_format", value = responseFormat.format)
-        edit.model?.let { model -> append(key = "model", value = model.id) }
         edit.n?.let { n -> append(key = "n", value = n) }
         edit.size?.let { dim -> append(key = "size", value = dim.size) }
         edit.user?.let { user -> append(key = "user", value = user) }
+        edit.model?.let { model -> append(key = "model", value = model.id) }
     }
 
     override suspend fun imageURL(variation: ImageVariation): List<ImageURL> {
@@ -87,19 +87,19 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
     private fun imageVariantRequest(edit: ImageVariation, responseFormat: ImageResponseFormat) = formData {
         appendFileSource("image", edit.image)
         append(key = "response_format", value = responseFormat.format)
-        edit.model?.let { model -> append(key = "model", value = model.id) }
         edit.n?.let { n -> append(key = "n", value = n) }
         edit.size?.let { dim -> append(key = "size", value = dim.size) }
         edit.user?.let { user -> append(key = "user", value = user) }
+        edit.model?.let { model -> append(key = "model", value = model.id) }
     }
 
     /** Convert [ImageCreation] instance to base64 JSON request */
     private fun ImageCreation.toJSONRequest() = ImageCreationRequest(
-        prompt = prompt, model = model?.id, n = n, size = size, user = user, responseFormat = ImageResponseFormat.base64Json,
+        prompt = prompt, n = n, size = size, user = user, responseFormat = ImageResponseFormat.base64Json, model = model?.id,
     )
 
     /** Convert [ImageCreation] instance to URL request */
     private fun ImageCreation.toURLRequest() = ImageCreationRequest(
-        prompt = prompt, model = model?.id, n = n, size = size, user = user, responseFormat = ImageResponseFormat.url,
+        prompt = prompt, n = n, size = size, user = user, responseFormat = ImageResponseFormat.url, model = model?.id
     )
 }

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageCreation.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageCreation.kt
@@ -13,10 +13,6 @@ public class ImageCreation(
      */
     public val prompt: String,
     /**
-     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
-     */
-    public val model: ModelId? = null,
-    /**
      * The number of images to generate. Must be between 1 and 10.
      */
     public val n: Int? = null,
@@ -28,14 +24,20 @@ public class ImageCreation(
     /**
      * The format in which the generated images are returned. Must be one of url or b64_json.
      */
-    public val user: String? = null
+    public val user: String? = null,
+
+    /**
+     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
+     */
+    public val model: ModelId? = null,
 )
 
 /**
  * Image generation request.
  */
 @BetaOpenAI
-public fun imageCreation(block: ImageCreationBuilder.() -> Unit): ImageCreation = ImageCreationBuilder().apply(block).build()
+public fun imageCreation(block: ImageCreationBuilder.() -> Unit): ImageCreation =
+    ImageCreationBuilder().apply(block).build()
 
 /**
  * Builder of [ImageCreation] instances.
@@ -48,11 +50,6 @@ public class ImageCreationBuilder {
      * A text description of the desired image(s). The maximum length is 1000 characters.
      */
     public var prompt: String? = null
-
-    /**
-     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
-     */
-    public val model: ModelId? = null
 
     /**
      * The number of images to generate. Must be between 1 and 10.
@@ -70,13 +67,18 @@ public class ImageCreationBuilder {
     public var user: String? = null
 
     /**
+     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
+     */
+    public var model: ModelId? = null
+
+    /**
      * Creates the [ImageCreation] instance
      */
     public fun build(): ImageCreation = ImageCreation(
         prompt = requireNotNull(prompt),
-        model = model,
         n = n,
         size = size,
         user = user,
+        model = model,
     )
 }

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageCreation.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageCreation.kt
@@ -2,6 +2,7 @@ package com.aallam.openai.api.image
 
 import com.aallam.openai.api.BetaOpenAI
 import com.aallam.openai.api.OpenAIDsl
+import com.aallam.openai.api.model.ModelId
 
 /**
  * Image generation request.
@@ -14,7 +15,7 @@ public class ImageCreation(
     /**
      * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
      */
-    public val model: String? = null,
+    public val model: ModelId? = null,
     /**
      * The number of images to generate. Must be between 1 and 10.
      */
@@ -51,7 +52,7 @@ public class ImageCreationBuilder {
     /**
      * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
      */
-    public val model: String? = null
+    public val model: ModelId? = null
 
     /**
      * The number of images to generate. Must be between 1 and 10.

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageCreation.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageCreation.kt
@@ -12,6 +12,10 @@ public class ImageCreation(
      */
     public val prompt: String,
     /**
+     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
+     */
+    public val model: String? = null,
+    /**
      * The number of images to generate. Must be between 1 and 10.
      */
     public val n: Int? = null,
@@ -45,6 +49,11 @@ public class ImageCreationBuilder {
     public var prompt: String? = null
 
     /**
+     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
+     */
+    public val model: String? = null
+
+    /**
      * The number of images to generate. Must be between 1 and 10.
      */
     public var n: Int? = null
@@ -64,8 +73,9 @@ public class ImageCreationBuilder {
      */
     public fun build(): ImageCreation = ImageCreation(
         prompt = requireNotNull(prompt),
+        model = model,
         n = n,
         size = size,
-        user = user
+        user = user,
     )
 }

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageEdit.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageEdit.kt
@@ -26,6 +26,11 @@ public class ImageEdit(
     public val prompt: String,
 
     /**
+     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
+     */
+    public val model: String? = null,
+
+    /**
      * The number of images to generate. Must be between 1 and 10.
      */
     public val n: Int? = null,
@@ -71,6 +76,11 @@ public class ImageEditBuilder {
     public var prompt: String? = null
 
     /**
+     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
+     */
+    public val model: String? = null
+
+    /**
      * The number of images to generate. Must be between 1 and 10.
      */
     public var n: Int? = null
@@ -92,6 +102,7 @@ public class ImageEditBuilder {
         image = requireNotNull(image) { "image field is required" },
         mask = requireNotNull(mask) { "mask field is required" },
         prompt = requireNotNull(prompt) { "prompt field is required" },
+        model = model,
         n = n,
         size = size,
         user = user

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageEdit.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageEdit.kt
@@ -27,11 +27,6 @@ public class ImageEdit(
     public val prompt: String,
 
     /**
-     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
-     */
-    public val model: ModelId? = null,
-
-    /**
      * The number of images to generate. Must be between 1 and 10.
      */
     public val n: Int? = null,
@@ -45,6 +40,11 @@ public class ImageEdit(
      * A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
      */
     public val user: String? = null,
+
+    /**
+     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
+     */
+    public val model: ModelId? = null,
 )
 
 /**
@@ -77,11 +77,6 @@ public class ImageEditBuilder {
     public var prompt: String? = null
 
     /**
-     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
-     */
-    public val model: ModelId? = null
-
-    /**
      * The number of images to generate. Must be between 1 and 10.
      */
     public var n: Int? = null
@@ -97,15 +92,20 @@ public class ImageEditBuilder {
     public var user: String? = null
 
     /**
+     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
+     */
+    public var model: ModelId? = null
+
+    /**
      * Creates the [ImageEdit] instance
      */
     public fun build(): ImageEdit = ImageEdit(
         image = requireNotNull(image) { "image field is required" },
         mask = requireNotNull(mask) { "mask field is required" },
         prompt = requireNotNull(prompt) { "prompt field is required" },
-        model = model,
         n = n,
         size = size,
-        user = user
+        user = user,
+        model = model,
     )
 }

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageEdit.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageEdit.kt
@@ -3,6 +3,7 @@ package com.aallam.openai.api.image
 import com.aallam.openai.api.BetaOpenAI
 import com.aallam.openai.api.OpenAIDsl
 import com.aallam.openai.api.file.FileSource
+import com.aallam.openai.api.model.ModelId
 
 /**
  * Image edit request.
@@ -28,7 +29,7 @@ public class ImageEdit(
     /**
      * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
      */
-    public val model: String? = null,
+    public val model: ModelId? = null,
 
     /**
      * The number of images to generate. Must be between 1 and 10.
@@ -78,7 +79,7 @@ public class ImageEditBuilder {
     /**
      * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
      */
-    public val model: String? = null
+    public val model: ModelId? = null
 
     /**
      * The number of images to generate. Must be between 1 and 10.

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageVariation.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageVariation.kt
@@ -14,6 +14,11 @@ public class ImageVariation(
     public val image: FileSource,
 
     /**
+     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
+     */
+    public val model: String? = null,
+
+    /**
      * The number of images to generate. Must be between 1 and 10.
      */
     public val n: Int? = null,
@@ -48,6 +53,11 @@ public class ImageVariationBuilder {
     public var image: FileSource? = null
 
     /**
+     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
+     */
+    public val model: String? = null
+
+    /**
      * The number of images to generate. Must be between 1 and 10.
      */
     public var n: Int? = null
@@ -67,6 +77,7 @@ public class ImageVariationBuilder {
      */
     public fun build(): ImageVariation = ImageVariation(
         image = requireNotNull(image) { "image is required" },
+        model = model,
         n = n,
         size = size,
         user = user

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageVariation.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageVariation.kt
@@ -15,11 +15,6 @@ public class ImageVariation(
     public val image: FileSource,
 
     /**
-     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
-     */
-    public val model: ModelId? = null,
-
-    /**
      * The number of images to generate. Must be between 1 and 10.
      */
     public val n: Int? = null,
@@ -33,6 +28,11 @@ public class ImageVariation(
      * A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
      */
     public val user: String? = null,
+
+    /**
+     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
+     */
+    public val model: ModelId? = null,
 )
 
 /**
@@ -54,11 +54,6 @@ public class ImageVariationBuilder {
     public var image: FileSource? = null
 
     /**
-     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
-     */
-    public val model: ModelId? = null
-
-    /**
      * The number of images to generate. Must be between 1 and 10.
      */
     public var n: Int? = null
@@ -74,13 +69,18 @@ public class ImageVariationBuilder {
     public var user: String? = null
 
     /**
+     * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
+     */
+    public var model: ModelId? = null
+
+    /**
      * Creates the [ImageVariation] instance
      */
     public fun build(): ImageVariation = ImageVariation(
         image = requireNotNull(image) { "image is required" },
-        model = model,
         n = n,
         size = size,
-        user = user
+        user = user,
+        model = model,
     )
 }

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageVariation.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/ImageVariation.kt
@@ -3,6 +3,7 @@ package com.aallam.openai.api.image
 import com.aallam.openai.api.BetaOpenAI
 import com.aallam.openai.api.OpenAIDsl
 import com.aallam.openai.api.file.FileSource
+import com.aallam.openai.api.model.ModelId
 
 /**
  * Image variant request.
@@ -16,7 +17,7 @@ public class ImageVariation(
     /**
      * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
      */
-    public val model: String? = null,
+    public val model: ModelId? = null,
 
     /**
      * The number of images to generate. Must be between 1 and 10.
@@ -55,7 +56,7 @@ public class ImageVariationBuilder {
     /**
      * The model used to generate image. Must be one of dall-e-2 or dall-e-3. If not provided, dall-e-2 is used.
      */
-    public val model: String? = null
+    public val model: ModelId? = null
 
     /**
      * The number of images to generate. Must be between 1 and 10.

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/internal/ImageCreationRequest.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/internal/ImageCreationRequest.kt
@@ -15,9 +15,9 @@ import kotlinx.serialization.Serializable
 @InternalOpenAI
 public data class ImageCreationRequest(
     @SerialName("prompt") val prompt: String,
-    @SerialName("model") val model: String?,
     @SerialName("n") val n: Int? = null,
     @SerialName("size") val size: ImageSize? = null,
     @SerialName("user") val user: String? = null,
     @SerialName("response_format") val responseFormat: ImageResponseFormat,
+    @SerialName("model") val model: String? = null,
 )

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/internal/ImageCreationRequest.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/image/internal/ImageCreationRequest.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.Serializable
 @InternalOpenAI
 public data class ImageCreationRequest(
     @SerialName("prompt") val prompt: String,
+    @SerialName("model") val model: String?,
     @SerialName("n") val n: Int? = null,
     @SerialName("size") val size: ImageSize? = null,
     @SerialName("user") val user: String? = null,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| New feature?      | yes
| BC breaks?        | no

## Describe your change
Allow to specify custom model for image creation, variations and edit as described in [API doc](https://platform.openai.com/docs/api-reference/images/createEdit) after recent update (REST API added support for DALL-E 3 model - https://help.openai.com/en/articles/8555480-dall-e-3-api)