### PR TITLE
fix: field 'tool_calls' is required for type with serial name 'submit_tool_outputs', but it was missing

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RequiredAction.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RequiredAction.kt
@@ -5,17 +5,19 @@ import com.aallam.openai.api.chat.ToolCall
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Details on the action required to continue the run.
+ */
 @BetaOpenAI
 @Serializable
-public data class RequiredAction(
-    @SerialName("submit_tool_outputs")
-    public val submitToolOutputs: SubmitToolOutputs? = null,
-) {
+public sealed interface RequiredAction {
+
     @Serializable
-    public data class SubmitToolOutputs(
+    @SerialName("submit_tool_outputs")
+    public class SubmitToolOutputs(
         /**
          * A list of the relevant tool calls.
          */
-        @SerialName("tool_calls") public val toolCalls: List<ToolCall>,
-    )
+        @SerialName("submit_tool_outputs") public val toolOutputs: ToolOutputs,
+    ) : RequiredAction
 }

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RequiredAction.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RequiredAction.kt
@@ -7,14 +7,15 @@ import kotlinx.serialization.Serializable
 
 @BetaOpenAI
 @Serializable
-public sealed interface RequiredAction {
-
-    @Serializable
+public data class RequiredAction(
     @SerialName("submit_tool_outputs")
-    public class SubmitToolOutputs(
+    public val submitToolOutputs: SubmitToolOutputs? = null,
+) {
+    @Serializable
+    public data class SubmitToolOutputs(
         /**
          * A list of the relevant tool calls.
          */
         @SerialName("tool_calls") public val toolCalls: List<ToolCall>,
-    ) : RequiredAction
+    )
 }

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RequiredAction.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RequiredAction.kt
@@ -1,7 +1,6 @@
 package com.aallam.openai.api.run
 
 import com.aallam.openai.api.BetaOpenAI
-import com.aallam.openai.api.chat.ToolCall
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/ToolOutputs.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/ToolOutputs.kt
@@ -1,0 +1,18 @@
+package com.aallam.openai.api.run
+
+import com.aallam.openai.api.BetaOpenAI
+import com.aallam.openai.api.chat.ToolCall
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Details on the tool outputs needed for this run to continue.
+ */
+@BetaOpenAI
+@Serializable
+public data class ToolOutputs(
+    /**
+     * A list of the relevant tool calls
+     */
+    @SerialName("tool_calls") val toolCalls: List<ToolCall>
+)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes

## Describe your change

Fixes `Field 'tool_calls' is required for type with serial name 'submit_tool_outputs', but it was missing`. API states that required action is the parent object:
![image](https://github.com/aallam/openai-kotlin/assets/150201955/4454845d-8198-420a-a7b7-828babc002df)

