### PR TITLE
fix: MissingFieldException: Fields [name, arguments] in ToolCallStep$FunctionTool

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunStepDetails.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunStepDetails.kt
@@ -89,19 +89,28 @@ public sealed interface ToolCallStep {
     @SerialName("function")
     public data class FunctionTool(
         /**
-         * The name of the function.
+         * The ID of the tool call object.
          */
-        @SerialName("name") public val name: String,
+        @SerialName("id") public val id: String,
+        /**
+         * The definition of the function that was called.
+         */
+        @SerialName("function") public val function: FunctionDefinition,
+    ) : ToolCallStep
+
+    @BetaOpenAI
+    @Serializable
+    public data class FunctionDefinition (
         /**
          * The arguments passed to the function.
          */
-        @SerialName("arguments") public val arguments: String,
+        @SerialName("arguments") public val arguments: String? = null,
 
         /**
          * The output of the function. This will be null if the outputs have not been submitted yet.
          */
         @SerialName("output") public val output: String? = null,
-    ) : ToolCallStep
+    )
 }
 
 @BetaOpenAI

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunStepDetails.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunStepDetails.kt
@@ -63,7 +63,7 @@ public sealed interface ToolCallStep {
         /**
          * The ID of the tool call.
          */
-        @SerialName("id") public val id: String,
+        @SerialName("id") public val id: ToolCallStepId,
         /**
          * The Code Interpreter tool call definition.
          */
@@ -77,7 +77,7 @@ public sealed interface ToolCallStep {
         /**
          * The ID of the tool call object.
          */
-        @SerialName("id") public val id: String,
+        @SerialName("id") public val id: ToolCallStepId,
         /**
          * For now, this is always going to be an empty object.
          */
@@ -91,27 +91,27 @@ public sealed interface ToolCallStep {
         /**
          * The ID of the tool call object.
          */
-        @SerialName("id") public val id: String,
+        @SerialName("id") public val id: ToolCallStepId,
         /**
          * The definition of the function that was called.
          */
-        @SerialName("function") public val function: FunctionDefinition,
+        @SerialName("function") public val function: FunctionToolCallStep,
     ) : ToolCallStep
-
-    @BetaOpenAI
-    @Serializable
-    public data class FunctionDefinition (
-        /**
-         * The arguments passed to the function.
-         */
-        @SerialName("arguments") public val arguments: String,
-
-        /**
-         * The output of the function. This will be null if the outputs have not been submitted yet.
-         */
-        @SerialName("output") public val output: String? = null,
-    )
 }
+
+@BetaOpenAI
+@Serializable
+public data class FunctionToolCallStep (
+    /**
+     * The arguments passed to the function.
+     */
+    @SerialName("arguments") public val arguments: String,
+
+    /**
+     * The output of the function. This will be null if the outputs have not been submitted yet.
+     */
+    @SerialName("output") public val output: String? = null,
+)
 
 @BetaOpenAI
 @Serializable
@@ -126,7 +126,6 @@ public data class CodeInterpreterToolCall(
      * (logs) or images (image). Each of these is represented by a different object type.
      */
     val outputs: List<CodeInterpreterToolCallOutput>
-
 )
 
 @BetaOpenAI

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunStepDetails.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunStepDetails.kt
@@ -104,7 +104,7 @@ public sealed interface ToolCallStep {
         /**
          * The arguments passed to the function.
          */
-        @SerialName("arguments") public val arguments: String? = null,
+        @SerialName("arguments") public val arguments: String,
 
         /**
          * The output of the function. This will be null if the outputs have not been submitted yet.

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/ToolCallStepId.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/ToolCallStepId.kt
@@ -1,0 +1,13 @@
+package com.aallam.openai.api.run
+
+import com.aallam.openai.api.BetaOpenAI
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
+
+/**
+ * Tool call step identifier.
+ */
+@BetaOpenAI
+@JvmInline
+@Serializable
+public value class ToolCallStepId(public val id: String)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes

## Describe your change

Fixes:

```
Caused by: kotlinx.serialization.MissingFieldException: Fields [name, arguments] are required for type with serial name 'function', but they were missing
		at kotlinx.serialization.internal.PluginExceptionsKt.throwMissingFieldException(PluginExceptions.kt:20)
		at com.aallam.openai.api.run.ToolCallStep$FunctionTool.<init>(RunStepDetails.kt:87)
		at com.aallam.openai.api.run.ToolCallStep$FunctionTool$$serializer.deserialize(RunStepDetails.kt:87)
		at com.aallam.openai.api.run.ToolCallStep$FunctionTool$$serializer.deserialize(RunStepDetails.kt:87)
```
