### PR TITLE
 chore: add missing name field to `FunctionToolCallStep`

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunStepDetails.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunStepDetails.kt
@@ -103,6 +103,11 @@ public sealed interface ToolCallStep {
 @Serializable
 public data class FunctionToolCallStep (
     /**
+     * The name of the function.
+     */
+    @SerialName("name") public val name: String,
+
+    /**
      * The arguments passed to the function.
      */
     @SerialName("arguments") public val arguments: String,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes

## Describe your change
Previous change renamed `name` to `id` instead of adding new `id` field. This adds `name` back to `FunctionToolCallStep`.