### PR TITLE
Fix incorrect property name (Run.canceledAt -> cancelledAt)

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/Run.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/Run.kt
@@ -61,9 +61,9 @@ public data class Run(
     @SerialName("started_at") val startedAt: Int? = null,
 
     /**
-     * The Unix timestamp (in seconds) for when the run was canceled.
+     * The Unix timestamp (in seconds) for when the run was cancelled.
      */
-    @SerialName("canceled_at") val canceledAt: Int? = null,
+    @SerialName("cancelled_at") val cancelledAt: Int? = null,
 
     /**
      * The Unix timestamp (in seconds) for when the run failed.


### PR DESCRIPTION
Noticed that my polling loop wouldn't stop when canceling a run and found that the property name didn't match when looking at the response body.

See https://platform.openai.com/docs/api-reference/runs/object#runs/object-cancelled_at - not sure if this was a typo in the library or if OpenAI changed this at some point.