### PR TITLE
Add EnclosingMethod proguard rule

### DIFF
--- a/openai-core/src/jvmMain/resources/META-INF/proguard/openai.pro
+++ b/openai-core/src/jvmMain/resources/META-INF/proguard/openai.pro
@@ -1,4 +1,5 @@
 -keepattributes InnerClasses
+-keepattributes EnclosingMethod
 
 -if @kotlinx.serialization.Serializable class
 com.aallam.openai.api.**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no

## Describe your change
Add an extra proguard rule `-keepattributes EnclosingMethod` which is required by the `InnerClasses` attribute rule. 
<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

## What problem is this fixing?
On Android, the `-keepattributes InnerClasses` proguard rule complains about missing `EnclosingMethod` attribute causing release builds with minification enabled to fail.

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->