### PR TITLE
fix(completion): `Choice.finishReason` as nullable

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/completion/Choice.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/completion/Choice.kt
@@ -37,5 +37,5 @@ public data class Choice(
      * request was reached.
      */
     @SerialName("finish_reason")
-    public val finishReason: FinishReason,
+    public val finishReason: FinishReason? = null,
 )


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #284 
