### PR TITLE
feat: add `RequestOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+- **Misc**: add `RequestOptions` 
+
 ## 3.6.3
 > Published 13 Jan 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Added
-- **Misc**: add `RequestOptions` 
+- add `RequestOptions` (#296)
 
 ## 3.6.3
 > Published 13 Jan 2024

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlin.js.compiler=ir
 
 # Lib
 GROUP=com.aallam.openai
-VERSION_NAME=3.6.3
+VERSION_NAME=3.7.0-SNAPSHOT
 
 # OSS
 SONATYPE_HOST=DEFAULT

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Assistants.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Assistants.kt
@@ -5,6 +5,7 @@ import com.aallam.openai.api.assistant.Assistant
 import com.aallam.openai.api.assistant.AssistantFile
 import com.aallam.openai.api.assistant.AssistantId
 import com.aallam.openai.api.assistant.AssistantRequest
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.core.SortOrder
 import com.aallam.openai.api.file.FileId
 
@@ -20,7 +21,7 @@ public interface Assistants {
      * @param request the request to create an assistant.
      */
     @BetaOpenAI
-    public suspend fun assistant(request: AssistantRequest): Assistant
+    public suspend fun assistant(request: AssistantRequest, requestOptions: RequestOptions? = null): Assistant
 
     /**
      * Retrieves an assistant.
@@ -28,7 +29,7 @@ public interface Assistants {
      * @param id the ID of the assistant to retrieve.
      */
     @BetaOpenAI
-    public suspend fun assistant(id: AssistantId): Assistant?
+    public suspend fun assistant(id: AssistantId, requestOptions: RequestOptions? = null): Assistant?
 
     /**
      * Update an assistant.
@@ -36,7 +37,11 @@ public interface Assistants {
      * @param id rhe ID of the assistant to modify.
      */
     @BetaOpenAI
-    public suspend fun assistant(id: AssistantId, request: AssistantRequest): Assistant
+    public suspend fun assistant(
+        id: AssistantId,
+        request: AssistantRequest,
+        requestOptions: RequestOptions? = null
+    ): Assistant
 
     /**
      * Delete an assistant.
@@ -44,7 +49,7 @@ public interface Assistants {
      * @param id ID of the assistant to delete.
      */
     @BetaOpenAI
-    public suspend fun delete(id: AssistantId): Boolean
+    public suspend fun delete(id: AssistantId, requestOptions: RequestOptions? = null): Boolean
 
     /**
      * Returns a list of assistants.
@@ -65,6 +70,7 @@ public interface Assistants {
         order: SortOrder? = null,
         after: AssistantId? = null,
         before: AssistantId? = null,
+        requestOptions: RequestOptions? = null
     ): List<Assistant>
 
     /**
@@ -75,7 +81,11 @@ public interface Assistants {
      * Useful for tools like retrieval and code interpreter that can access files.
      */
     @BetaOpenAI
-    public suspend fun createFile(assistantId: AssistantId, fileId: FileId): AssistantFile
+    public suspend fun createFile(
+        assistantId: AssistantId,
+        fileId: FileId,
+        requestOptions: RequestOptions? = null
+    ): AssistantFile
 
     /**
      * Retrieves an [AssistantFile].
@@ -84,16 +94,21 @@ public interface Assistants {
      * @param fileId the ID of the file we're getting.
      */
     @BetaOpenAI
-    public suspend fun file(assistantId: AssistantId, fileId: FileId): AssistantFile
+    public suspend fun file(
+        assistantId: AssistantId,
+        fileId: FileId,
+        requestOptions: RequestOptions? = null
+    ): AssistantFile
 
     /**
      * Delete an assistant file.
      *
      * @param assistantId the ID of the assistant that the file belongs to.
      * @param fileId the ID of the file to delete.
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun delete(assistantId: AssistantId, fileId: FileId): Boolean
+    public suspend fun delete(assistantId: AssistantId, fileId: FileId, requestOptions: RequestOptions? = null): Boolean
 
     /**
      * Returns a list of assistant files.
@@ -108,6 +123,7 @@ public interface Assistants {
      * @param before a cursor for use in pagination. Before is an object ID that defines your place in the list.
      * For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can
      * include `before = FileId("obj_foo")` in order to fetch the previous page of the list.
+     * @param requestOptions request options.
      */
     @BetaOpenAI
     public suspend fun files(
@@ -116,5 +132,6 @@ public interface Assistants {
         order: SortOrder? = null,
         after: FileId? = null,
         before: FileId? = null,
+        requestOptions: RequestOptions? = null
     ): List<AssistantFile>
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Audio.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Audio.kt
@@ -1,6 +1,7 @@
 package com.aallam.openai.client
 
 import com.aallam.openai.api.audio.*
+import com.aallam.openai.api.core.RequestOptions
 
 /**
  * Learn how to turn audio into text.
@@ -9,16 +10,28 @@ public interface Audio {
 
     /**
      * Transcribes audio into the input language.
+     *
+     * @param request transcription request.
+     * @param requestOptions request options.
      */
-    public suspend fun transcription(request: TranscriptionRequest): Transcription
+    public suspend fun transcription(
+        request: TranscriptionRequest,
+        requestOptions: RequestOptions? = null
+    ): Transcription
 
     /**
      * Translates audio into English.
+     *
+     * @param request translation request.
+     * @param requestOptions request options.
      */
-    public suspend fun translation(request: TranslationRequest): Translation
+    public suspend fun translation(request: TranslationRequest, requestOptions: RequestOptions? = null): Translation
 
     /**
      * Generates audio from the input text.
+     *
+     * @param request speech request.
+     * @param requestOptions request options.
      */
-    public suspend fun speech(request: SpeechRequest): ByteArray
+    public suspend fun speech(request: SpeechRequest, requestOptions: RequestOptions? = null): ByteArray
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Chat.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Chat.kt
@@ -3,6 +3,7 @@ package com.aallam.openai.client
 import com.aallam.openai.api.chat.ChatCompletion
 import com.aallam.openai.api.chat.ChatCompletionChunk
 import com.aallam.openai.api.chat.ChatCompletionRequest
+import com.aallam.openai.api.core.RequestOptions
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -12,11 +13,23 @@ public interface Chat {
 
     /**
      * Creates a completion for the chat message.
+     *
+     * @param request completion request.
+     * @param requestOptions request options.
      */
-    public suspend fun chatCompletion(request: ChatCompletionRequest): ChatCompletion
+    public suspend fun chatCompletion(
+        request: ChatCompletionRequest,
+        requestOptions: RequestOptions? = null
+    ): ChatCompletion
 
     /**
      * Stream variant of [chatCompletion].
+     *
+     * @param request completion request.
+     * @param requestOptions request options.
      */
-    public fun chatCompletions(request: ChatCompletionRequest): Flow<ChatCompletionChunk>
+    public fun chatCompletions(
+        request: ChatCompletionRequest,
+        requestOptions: RequestOptions? = null
+    ): Flow<ChatCompletionChunk>
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Embeddings.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Embeddings.kt
@@ -1,5 +1,6 @@
 package com.aallam.openai.client
 
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.embedding.EmbeddingRequest
 import com.aallam.openai.api.embedding.EmbeddingResponse
 
@@ -10,6 +11,9 @@ public interface Embeddings {
 
     /**
      * Creates an embedding vector representing the input text.
+     *
+     * @param request embedding request.
+     * @param requestOptions request options.
      */
-    public suspend fun embeddings(request: EmbeddingRequest): EmbeddingResponse
+    public suspend fun embeddings(request: EmbeddingRequest, requestOptions: RequestOptions? = null): EmbeddingResponse
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Files.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Files.kt
@@ -1,8 +1,9 @@
 package com.aallam.openai.client
 
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.file.File
-import com.aallam.openai.api.file.FileUpload
 import com.aallam.openai.api.file.FileId
+import com.aallam.openai.api.file.FileUpload
 
 /**
  * Files are used to upload documents that can be used across features like [Answers], [Searches], and [Classifications]
@@ -12,26 +13,40 @@ public interface Files {
     /**
      * Upload a file that contains document(s) to be used across various endpoints/features.
      * Currently, the size of all the files uploaded by one organization can be up to 1 GB.
+     *
+     * @param request file upload request.
+     * @param requestOptions request options.
      */
-    public suspend fun file(request: FileUpload): File
+    public suspend fun file(request: FileUpload, requestOptions: RequestOptions? = null): File
 
     /**
      * Returns a list of files that belong to the user's organization.
+     *
+     * @param requestOptions request options.
      */
-    public suspend fun files(): List<File>
+    public suspend fun files(requestOptions: RequestOptions? = null): List<File>
 
     /**
      * Returns information about a specific file.
+     *
+     * @param fileId the ID of the file to retrieve.
+     * @param requestOptions request options.
      */
-    public suspend fun file(fileId: FileId): File?
+    public suspend fun file(fileId: FileId, requestOptions: RequestOptions? = null): File?
 
     /**
      * Delete a file. Only owners of organizations can delete files currently.
+     *
+     * @param fileId the ID of the file to delete.
+     * @param requestOptions request options.
      */
-    public suspend fun delete(fileId: FileId): Boolean
+    public suspend fun delete(fileId: FileId, requestOptions: RequestOptions? = null): Boolean
 
     /**
      * Returns the contents of the specified [fileId].
+     *
+     * @param fileId the ID of the file to download.
+     * @param requestOptions request options.
      */
-    public suspend fun download(fileId: FileId): ByteArray
+    public suspend fun download(fileId: FileId, requestOptions: RequestOptions? = null): ByteArray
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/FineTuning.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/FineTuning.kt
@@ -1,7 +1,11 @@
 package com.aallam.openai.client
 
 import com.aallam.openai.api.core.PaginatedList
-import com.aallam.openai.api.finetuning.*
+import com.aallam.openai.api.core.RequestOptions
+import com.aallam.openai.api.finetuning.FineTuningId
+import com.aallam.openai.api.finetuning.FineTuningJob
+import com.aallam.openai.api.finetuning.FineTuningJobEvent
+import com.aallam.openai.api.finetuning.FineTuningRequest
 
 /**
  * Manage fine-tuning jobs to tailor a model to your specific training data.
@@ -11,31 +15,41 @@ public interface FineTuning {
     /**
      * Creates a job that fine-tunes a specified model from a given dataset.
      *
-     * Response includes details of the enqueued job including job status and the name of the fine-tuned models once complete.
+     * The response includes details of the enqueued job including job status and the name of the fine-tuned models once complete.
+     *
+     * @param request fine-tuning request.
+     * @param requestOptions request options.
      */
-    public suspend fun fineTuningJob(request: FineTuningRequest): FineTuningJob
+    public suspend fun fineTuningJob(request: FineTuningRequest, requestOptions: RequestOptions? = null): FineTuningJob
 
     /**
      * List your organization's fine-tuning jobs.
      *
      * @param after Identifier for the last job from the previous pagination request.
      * @param limit Number of fine-tuning jobs to retrieve.
+     * @param requestOptions request options.
      */
-    public suspend fun fineTuningJobs(after: String? = null, limit: Int? = null): List<FineTuningJob>
+    public suspend fun fineTuningJobs(
+        after: String? = null,
+        limit: Int? = null,
+        requestOptions: RequestOptions? = null
+    ): List<FineTuningJob>
 
     /**
      * Get info about a fine-tuning job.
      *
      * @param id The ID of the fine-tuning job.
+     * @param requestOptions request options.
      */
-    public suspend fun fineTuningJob(id: FineTuningId): FineTuningJob?
+    public suspend fun fineTuningJob(id: FineTuningId, requestOptions: RequestOptions? = null): FineTuningJob?
 
     /**
      * Immediately cancel a fine-tune job.
      *
      * @param id The ID of the fine-tuning job to cancel.
+     * @param requestOptions request options.
      */
-    public suspend fun cancel(id: FineTuningId): FineTuningJob?
+    public suspend fun cancel(id: FineTuningId, requestOptions: RequestOptions? = null): FineTuningJob?
 
     /**
      * Get status updates for a fine-tuning job.
@@ -43,10 +57,11 @@ public interface FineTuning {
      * @param id The ID of the fine-tuning job to get events for.
      * @param after Identifier for the last event from the previous pagination request.
      * @param limit Number of events to retrieve.
+     * @param requestOptions request options.
      */
     public suspend fun fineTuningEvents(
         id: FineTuningId,
         after: String? = null,
-        limit: Int? = null
+        limit: Int? = null, requestOptions: RequestOptions? = null
     ): PaginatedList<FineTuningJobEvent>
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Images.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Images.kt
@@ -1,5 +1,6 @@
 package com.aallam.openai.client
 
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.image.*
 
 /**
@@ -10,36 +11,54 @@ public interface Images {
     /**
      * Creates an image given a prompt.
      * Get images as URLs.
+     *
+     * @param creation image creation request.
+     * @param requestOptions request options.
      */
-    public suspend fun imageURL(creation: ImageCreation): List<ImageURL>
+    public suspend fun imageURL(creation: ImageCreation, requestOptions: RequestOptions? = null): List<ImageURL>
 
     /**
      * Creates an image given a prompt.
      * Get images as base 64 JSON.
+     *
+     * @param creation image creation request.
+     * @param requestOptions request options.
      */
-    public suspend fun imageJSON(creation: ImageCreation): List<ImageJSON>
+    public suspend fun imageJSON(creation: ImageCreation, requestOptions: RequestOptions? = null): List<ImageJSON>
 
     /**
      * Creates an edited or extended image given an original image and a prompt.
      * Get images as URLs.
+     *
+     * @param edit image edit request.
+     * @param requestOptions request options.
      */
-    public suspend fun imageURL(edit: ImageEdit): List<ImageURL>
+    public suspend fun imageURL(edit: ImageEdit, requestOptions: RequestOptions? = null): List<ImageURL>
 
     /**
      * Creates an edited or extended image given an original image and a prompt.
      * Get images as base 64 JSON.
+     *
+     * @param edit image edit request.
+     * @param requestOptions request options.
      */
-    public suspend fun imageJSON(edit: ImageEdit): List<ImageJSON>
+    public suspend fun imageJSON(edit: ImageEdit, requestOptions: RequestOptions? = null): List<ImageJSON>
 
     /**
      * Creates a variation of a given image.
      * Get images as URLs.
+     *
+     * @param variation image variation request.
+     * @param requestOptions request options.
      */
-    public suspend fun imageURL(variation: ImageVariation): List<ImageURL>
+    public suspend fun imageURL(variation: ImageVariation, requestOptions: RequestOptions? = null): List<ImageURL>
 
     /**
      * Creates a variation of a given image.
      * Get images as base 64 JSON.
+     *
+     * @param variation image variation request.
+     * @param requestOptions request options.
      */
-    public suspend fun imageJSON(variation: ImageVariation): List<ImageJSON>
+    public suspend fun imageJSON(variation: ImageVariation, requestOptions: RequestOptions? = null): List<ImageJSON>
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Messages.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Messages.kt
@@ -1,6 +1,7 @@
 package com.aallam.openai.client
 
 import com.aallam.openai.api.BetaOpenAI
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.core.SortOrder
 import com.aallam.openai.api.file.FileId
 import com.aallam.openai.api.message.Message
@@ -20,18 +21,28 @@ public interface Messages {
      *
      * @param threadId the identifier of the thread
      * @param request message creation request
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun message(threadId: ThreadId, request: MessageRequest): Message
+    public suspend fun message(
+        threadId: ThreadId,
+        request: MessageRequest,
+        requestOptions: RequestOptions? = null
+    ): Message
 
     /**
      * Retrieve a message.
      *
      * @param threadId the identifier of the thread
      * @param messageId the identifier of the message
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun message(threadId: ThreadId, messageId: MessageId): Message
+    public suspend fun message(
+        threadId: ThreadId,
+        messageId: MessageId,
+        requestOptions: RequestOptions? = null
+    ): Message
 
     /**
      * Modify a message.
@@ -41,9 +52,15 @@ public interface Messages {
      * @param metadata set of 16 key-value pairs that can be attached to an object.
      * This can be useful for storing additional information about the object in a structured format.
      * Keys can be a maximum of 64 characters long, and values can be a maximum of 512 characters long.
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun message(threadId: ThreadId, messageId: MessageId, metadata: Map<String, String>? = null): Message
+    public suspend fun message(
+        threadId: ThreadId,
+        messageId: MessageId,
+        metadata: Map<String, String>? = null,
+        requestOptions: RequestOptions? = null
+    ): Message
 
     /**
      * Returns a list of messages for a given thread.
@@ -58,6 +75,7 @@ public interface Messages {
      * @param before a cursor for use in pagination. [before] is an object ID that defines your place in the list.
      * For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call
      * can include `before = MessageId("obj_foo")` in order to fetch the previous page of the list.
+     * @param requestOptions request options.
      */
     @BetaOpenAI
     public suspend fun messages(
@@ -66,6 +84,7 @@ public interface Messages {
         order: SortOrder? = null,
         after: MessageId? = null,
         before: MessageId? = null,
+        requestOptions: RequestOptions? = null
     ): List<Message>
 
     /**
@@ -74,9 +93,15 @@ public interface Messages {
      * @param threadId the ID of the thread to which the message and File belong
      * @param messageId the ID of the message the file belongs to
      * @param fileId the ID of the file being retrieved
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun messageFile(threadId: ThreadId, messageId: MessageId, fileId: FileId): MessageFile
+    public suspend fun messageFile(
+        threadId: ThreadId,
+        messageId: MessageId,
+        fileId: FileId,
+        requestOptions: RequestOptions? = null
+    ): MessageFile
 
     /**
      * Returns a list of message files.
@@ -91,6 +116,7 @@ public interface Messages {
      * @param before a cursor for use in pagination. [before] is an object ID that defines your place in the list.
      * For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call
      * can include `before = FileId("obj_foo")` in order to fetch the previous page of the list.
+     * @param requestOptions request options.
      */
     @BetaOpenAI
     public suspend fun messageFiles(
@@ -100,5 +126,6 @@ public interface Messages {
         order: SortOrder? = null,
         after: FileId? = null,
         before: FileId? = null,
+        requestOptions: RequestOptions? = null
     ): List<MessageFile>
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Models.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Models.kt
@@ -1,5 +1,6 @@
 package com.aallam.openai.client
 
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.model.Model
 import com.aallam.openai.api.model.ModelId
 
@@ -13,11 +14,16 @@ public interface Models {
     /**
      * Lists the currently available models, and provides basic information about each one
      * such as the owner and availability.
+     *
+     * @param requestOptions request options.
      */
-    public suspend fun models(): List<Model>
+    public suspend fun models(requestOptions: RequestOptions? = null): List<Model>
 
     /**
-     * Retrieves a model instance, providing basic information about the model such as the owner and permissioning.
+     * Retrieves a model instance, providing basic information about the model such as the owner and permission.
+     *
+     * @param modelId the identifier of the model.
+     * @param requestOptions request options.
      */
-    public suspend fun model(modelId: ModelId): Model
+    public suspend fun model(modelId: ModelId, requestOptions: RequestOptions? = null): Model
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Moderations.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Moderations.kt
@@ -1,5 +1,6 @@
 package com.aallam.openai.client
 
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.moderation.ModerationRequest
 import com.aallam.openai.api.moderation.TextModeration
 
@@ -9,7 +10,10 @@ import com.aallam.openai.api.moderation.TextModeration
 public interface Moderations {
 
     /**
-     * Classifies if text violates OpenAI's Content Policy.
+     * Classifies if a text violates OpenAI's Content Policy.
+     *
+     * @param request moderation request.
+     * @param requestOptions request options.
      */
-    public suspend fun moderations(request: ModerationRequest): TextModeration
+    public suspend fun moderations(request: ModerationRequest, requestOptions: RequestOptions? = null): TextModeration
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Runs.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Runs.kt
@@ -1,6 +1,7 @@
 package com.aallam.openai.client
 
 import com.aallam.openai.api.BetaOpenAI
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.core.SortOrder
 import com.aallam.openai.api.core.Status
 import com.aallam.openai.api.run.*
@@ -17,19 +18,20 @@ public interface Runs {
      *
      * @param threadId The ID of the thread to run
      * @param request request for a run
-     *
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun createRun(threadId: ThreadId, request: RunRequest): Run
+    public suspend fun createRun(threadId: ThreadId, request: RunRequest, requestOptions: RequestOptions? = null): Run
 
     /**
      * Retrieves a run.
      *
      * @param threadId The ID of the thread to run
      * @param runId The ID of the run to retrieve
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun getRun(threadId: ThreadId, runId: RunId): Run
+    public suspend fun getRun(threadId: ThreadId, runId: RunId, requestOptions: RequestOptions? = null): Run
 
     /**
      * Modifies a run.
@@ -39,9 +41,15 @@ public interface Runs {
      * @param metadata set of 16 key-value pairs that can be attached to an object.
      * This can be useful for storing additional information about the object in a structured format.
      * Keys can be a maximum of 64 characters long, and values can be a maximum of 512 characters long.
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun updateRun(threadId: ThreadId, runId: RunId, metadata: Map<String, String>? = null): Run
+    public suspend fun updateRun(
+        threadId: ThreadId,
+        runId: RunId,
+        metadata: Map<String, String>? = null,
+        requestOptions: RequestOptions? = null
+    ): Run
 
     /**
      * Returns a list of runs belonging to a thread.
@@ -54,6 +62,7 @@ public interface Runs {
      * @param before a cursor for use in pagination. [before] is an object ID that defines your place in the list.
      * For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call
      * can include `before = RunId("obj_foo")` in order to fetch the previous page of the list.
+     * @param requestOptions request options.
      */
     @BetaOpenAI
     public suspend fun runs(
@@ -62,32 +71,45 @@ public interface Runs {
         order: SortOrder? = null,
         after: RunId? = null,
         before: RunId? = null,
+        requestOptions: RequestOptions? = null
     ): List<Run>
 
     /**
      * When a run has the status: [Status.RequiresAction] and required action is [RequiredAction.SubmitToolOutputs],
      * this endpoint can be used to submit the outputs from the tool calls once they're all completed.
      * All outputs must be submitted in a single request.
+     *
+     * @param threadId the ID of the thread to which this run belongs
+     * @param runId the ID of the run to submit tool outputs for
+     * @param output list of tool outputs to submit
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun submitToolOutput(threadId: ThreadId, runId: RunId, output: List<ToolOutput>): Run
+    public suspend fun submitToolOutput(
+        threadId: ThreadId,
+        runId: RunId,
+        output: List<ToolOutput>,
+        requestOptions: RequestOptions? = null
+    ): Run
 
     /**
      * Cancels a run that is [Status.InProgress].
      *
      * @param threadId the ID of the thread to which this run belongs
      * @param runId the ID of the run to cancel
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun cancel(threadId: ThreadId, runId: RunId): Run
+    public suspend fun cancel(threadId: ThreadId, runId: RunId, requestOptions: RequestOptions? = null): Run
 
     /**
      * Create a thread and run it in one request.
      *
      * @param request request for a thread run
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun createThreadRun(request: ThreadRunRequest): Run
+    public suspend fun createThreadRun(request: ThreadRunRequest, requestOptions: RequestOptions? = null): Run
 
     /**
      * Retrieves a run step.
@@ -95,9 +117,15 @@ public interface Runs {
      * @param threadId the ID of the thread to which the run and run step belongs
      * @param runId the ID of the run to which the run step belongs
      * @param stepId the ID of the run step to retrieve
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun runStep(threadId: ThreadId, runId: RunId, stepId: RunStepId): RunStep
+    public suspend fun runStep(
+        threadId: ThreadId,
+        runId: RunId,
+        stepId: RunStepId,
+        requestOptions: RequestOptions? = null
+    ): RunStep
 
     /**
      * Retrieves a run step.
@@ -113,6 +141,7 @@ public interface Runs {
      * @param before a cursor for use in pagination. [before] is an object ID that defines your place in the list.
      * For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call
      * can include `before = RunId("obj_foo")` in order to fetch the previous page of the list.
+     * @param requestOptions request options.
      */
     @BetaOpenAI
     public suspend fun runSteps(
@@ -122,5 +151,6 @@ public interface Runs {
         order: SortOrder? = null,
         after: RunStepId? = null,
         before: RunStepId? = null,
+        requestOptions: RequestOptions? = null
     ): List<RunStep>
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Threads.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Threads.kt
@@ -1,6 +1,7 @@
 package com.aallam.openai.client
 
 import com.aallam.openai.api.BetaOpenAI
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.thread.Thread
 import com.aallam.openai.api.thread.ThreadId
 import com.aallam.openai.api.thread.ThreadRequest
@@ -15,17 +16,19 @@ public interface Threads {
      * Create a thread.
      *
      * @param request thread creation request.
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun thread(request: ThreadRequest? = null): Thread
+    public suspend fun thread(request: ThreadRequest? = null, requestOptions: RequestOptions? = null): Thread
 
     /**
      * Retrieve a thread.
      *
      * @param id the identifier of the thread.
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun thread(id: ThreadId): Thread?
+    public suspend fun thread(id: ThreadId, requestOptions: RequestOptions? = null): Thread?
 
     /**
      * Modify a thread.
@@ -34,15 +37,21 @@ public interface Threads {
      * @param metadata set of 16 key-value pairs that can be attached to an object.
      * This can be useful for storing additional information about the object in a structured format.
      * Keys can be a maximum of 64 characters long, and values can be a maximum of 512 characters long.
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun thread(id: ThreadId, metadata: Map<String, String>): Thread
+    public suspend fun thread(
+        id: ThreadId,
+        metadata: Map<String, String>,
+        requestOptions: RequestOptions? = null
+    ): Thread
 
     /**
      * Delete a thread.
      *
      * @param id the identifier of the thread.
+     * @param requestOptions request options.
      */
     @BetaOpenAI
-    public suspend fun delete(id: ThreadId): Boolean
+    public suspend fun delete(id: ThreadId, requestOptions: RequestOptions? = null): Boolean
 }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/AssistantsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/AssistantsApi.kt
@@ -7,11 +7,13 @@ import com.aallam.openai.api.assistant.AssistantId
 import com.aallam.openai.api.assistant.AssistantRequest
 import com.aallam.openai.api.core.DeleteResponse
 import com.aallam.openai.api.core.ListResponse
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.core.SortOrder
 import com.aallam.openai.api.exception.OpenAIAPIException
 import com.aallam.openai.api.file.FileId
 import com.aallam.openai.client.Assistants
 import com.aallam.openai.client.internal.extension.beta
+import com.aallam.openai.client.internal.extension.requestOptions
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
 import io.ktor.client.call.*
@@ -23,24 +25,26 @@ import kotlinx.serialization.json.put
 
 internal class AssistantsApi(val requester: HttpRequester) : Assistants {
     @BetaOpenAI
-    override suspend fun assistant(request: AssistantRequest): Assistant {
+    override suspend fun assistant(request: AssistantRequest, requestOptions: RequestOptions?): Assistant {
         return requester.perform {
             it.post {
                 url(path = ApiPath.Assistants)
                 setBody(request)
                 contentType(ContentType.Application.Json)
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
     @BetaOpenAI
-    override suspend fun assistant(id: AssistantId): Assistant? {
+    override suspend fun assistant(id: AssistantId, requestOptions: RequestOptions?): Assistant? {
         try {
             return requester.perform<HttpResponse> {
                 it.get {
                     url(path = "${ApiPath.Assistants}/${id.id}")
                     beta("assistants", 1)
+                    requestOptions(requestOptions)
                 }
             }.body()
         } catch (e: OpenAIAPIException) {
@@ -50,23 +54,29 @@ internal class AssistantsApi(val requester: HttpRequester) : Assistants {
     }
 
     @BetaOpenAI
-    override suspend fun assistant(id: AssistantId, request: AssistantRequest): Assistant {
+    override suspend fun assistant(
+        id: AssistantId,
+        request: AssistantRequest,
+        requestOptions: RequestOptions?
+    ): Assistant {
         return requester.perform {
             it.post {
                 url(path = "${ApiPath.Assistants}/${id.id}")
                 setBody(request)
                 contentType(ContentType.Application.Json)
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
     @BetaOpenAI
-    override suspend fun delete(id: AssistantId): Boolean {
+    override suspend fun delete(id: AssistantId, requestOptions: RequestOptions?): Boolean {
         val response = requester.perform<HttpResponse> {
             it.delete {
                 url(path = "${ApiPath.Assistants}/${id.id}")
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }
         }
         return when (response.status) {
@@ -76,11 +86,12 @@ internal class AssistantsApi(val requester: HttpRequester) : Assistants {
     }
 
     @BetaOpenAI
-    override suspend fun delete(assistantId: AssistantId, fileId: FileId): Boolean {
+    override suspend fun delete(assistantId: AssistantId, fileId: FileId, requestOptions: RequestOptions?): Boolean {
         val response = requester.perform<HttpResponse> {
             it.delete {
                 url(path = "${ApiPath.Assistants}/${assistantId.id}/files/${fileId.id}")
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }
         }
         return when (response.status) {
@@ -95,7 +106,8 @@ internal class AssistantsApi(val requester: HttpRequester) : Assistants {
         limit: Int?,
         order: SortOrder?,
         after: AssistantId?,
-        before: AssistantId?
+        before: AssistantId?,
+        requestOptions: RequestOptions?
     ): List<Assistant> {
         return requester.perform<ListResponse<Assistant>> { client ->
             client.get {
@@ -107,12 +119,17 @@ internal class AssistantsApi(val requester: HttpRequester) : Assistants {
                     before?.let { parameter("before", it.id) }
                 }
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
     @BetaOpenAI
-    override suspend fun createFile(assistantId: AssistantId, fileId: FileId): AssistantFile {
+    override suspend fun createFile(
+        assistantId: AssistantId,
+        fileId: FileId,
+        requestOptions: RequestOptions?
+    ): AssistantFile {
         val request = buildJsonObject { put("file", fileId.id) }
         return requester.perform {
             it.post {
@@ -120,16 +137,22 @@ internal class AssistantsApi(val requester: HttpRequester) : Assistants {
                 setBody(request)
                 contentType(ContentType.Application.Json)
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
     @BetaOpenAI
-    override suspend fun file(assistantId: AssistantId, fileId: FileId): AssistantFile {
+    override suspend fun file(
+        assistantId: AssistantId,
+        fileId: FileId,
+        requestOptions: RequestOptions?
+    ): AssistantFile {
         return requester.perform {
             it.get {
                 url(path = "${ApiPath.Assistants}/${assistantId.id}/files/${fileId.id}")
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }
         }
     }
@@ -141,6 +164,7 @@ internal class AssistantsApi(val requester: HttpRequester) : Assistants {
         order: SortOrder?,
         after: FileId?,
         before: FileId?,
+        requestOptions: RequestOptions?
     ): List<AssistantFile> {
         return requester.perform<ListResponse<AssistantFile>> { client ->
             client.get {
@@ -152,6 +176,7 @@ internal class AssistantsApi(val requester: HttpRequester) : Assistants {
                     before?.let { parameter("before", it.id) }
                 }
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/AudioApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/AudioApi.kt
@@ -2,8 +2,10 @@ package com.aallam.openai.client.internal.api
 
 import com.aallam.openai.api.BetaOpenAI
 import com.aallam.openai.api.audio.*
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.client.Audio
 import com.aallam.openai.client.internal.extension.appendFileSource
+import com.aallam.openai.client.internal.extension.requestOptions
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
 import io.ktor.client.request.*
@@ -15,22 +17,36 @@ import io.ktor.http.*
  */
 internal class AudioApi(val requester: HttpRequester) : Audio {
     @BetaOpenAI
-    override suspend fun transcription(request: TranscriptionRequest): Transcription {
+    override suspend fun transcription(request: TranscriptionRequest, requestOptions: RequestOptions?): Transcription {
         return when (request.responseFormat) {
-            AudioResponseFormat.Json, AudioResponseFormat.VerboseJson, null -> transcriptionAsJson(request)
-            else -> transcriptionAsString(request)
+            AudioResponseFormat.Json, AudioResponseFormat.VerboseJson, null -> transcriptionAsJson(
+                request,
+                requestOptions
+            )
+
+            else -> transcriptionAsString(request, requestOptions)
         }
     }
 
-    private suspend fun transcriptionAsJson(request: TranscriptionRequest): Transcription {
+    private suspend fun transcriptionAsJson(
+        request: TranscriptionRequest,
+        requestOptions: RequestOptions?
+    ): Transcription {
         return requester.perform {
-            it.submitFormWithBinaryData(url = ApiPath.Transcription, formData = formDataOf(request))
+            it.submitFormWithBinaryData(url = ApiPath.Transcription, formData = formDataOf(request)) {
+                requestOptions(requestOptions)
+            }
         }
     }
 
-    private suspend fun transcriptionAsString(request: TranscriptionRequest): Transcription {
+    private suspend fun transcriptionAsString(
+        request: TranscriptionRequest,
+        requestOptions: RequestOptions?
+    ): Transcription {
         val text = requester.perform<String> {
-            it.submitFormWithBinaryData(url = ApiPath.Transcription, formData = formDataOf(request))
+            it.submitFormWithBinaryData(url = ApiPath.Transcription, formData = formDataOf(request)) {
+                requestOptions(requestOptions)
+            }
         }
         return Transcription(text)
     }
@@ -48,22 +64,26 @@ internal class AudioApi(val requester: HttpRequester) : Audio {
     }
 
     @BetaOpenAI
-    override suspend fun translation(request: TranslationRequest): Translation {
+    override suspend fun translation(request: TranslationRequest, requestOptions: RequestOptions?): Translation {
         return when (request.responseFormat) {
-            "json", "verbose_json", null -> translationAsJson(request)
-            else -> translationAsString(request)
+            "json", "verbose_json", null -> translationAsJson(request, requestOptions)
+            else -> translationAsString(request, requestOptions)
         }
     }
 
-    private suspend fun translationAsJson(request: TranslationRequest): Translation {
+    private suspend fun translationAsJson(request: TranslationRequest, requestOptions: RequestOptions?): Translation {
         return requester.perform {
-            it.submitFormWithBinaryData(url = ApiPath.Translation, formData = formDataOf(request))
+            it.submitFormWithBinaryData(url = ApiPath.Translation, formData = formDataOf(request)) {
+                requestOptions(requestOptions)
+            }
         }
     }
 
-    private suspend fun translationAsString(request: TranslationRequest): Translation {
+    private suspend fun translationAsString(request: TranslationRequest, requestOptions: RequestOptions?): Translation {
         val text = requester.perform<String> {
-            it.submitFormWithBinaryData(url = ApiPath.Translation, formData = formDataOf(request))
+            it.submitFormWithBinaryData(url = ApiPath.Translation, formData = formDataOf(request)) {
+                requestOptions(requestOptions)
+            }
         }
         return Translation(text)
     }
@@ -79,12 +99,13 @@ internal class AudioApi(val requester: HttpRequester) : Audio {
         request.temperature?.let { append(key = "temperature", value = it) }
     }
 
-    override suspend fun speech(request: SpeechRequest): ByteArray {
+    override suspend fun speech(request: SpeechRequest, requestOptions: RequestOptions?): ByteArray {
         return requester.perform {
-            it.post{
+            it.post {
                 url(ApiPath.Speech)
                 setBody(request)
                 contentType(ContentType.Application.Json)
+                requestOptions(requestOptions)
             }
         }
     }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ChatApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ChatApi.kt
@@ -3,7 +3,9 @@ package com.aallam.openai.client.internal.api
 import com.aallam.openai.api.chat.ChatCompletion
 import com.aallam.openai.api.chat.ChatCompletionChunk
 import com.aallam.openai.api.chat.ChatCompletionRequest
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.client.Chat
+import com.aallam.openai.client.internal.extension.requestOptions
 import com.aallam.openai.client.internal.extension.streamEventsFrom
 import com.aallam.openai.client.internal.extension.streamRequestOf
 import com.aallam.openai.client.internal.http.HttpRequester
@@ -15,17 +17,24 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 internal class ChatApi(private val requester: HttpRequester) : Chat {
-    override suspend fun chatCompletion(request: ChatCompletionRequest): ChatCompletion {
+    override suspend fun chatCompletion(
+        request: ChatCompletionRequest,
+        requestOptions: RequestOptions?
+    ): ChatCompletion {
         return requester.perform {
             it.post {
                 url(path = ApiPath.ChatCompletions)
                 setBody(request)
                 contentType(ContentType.Application.Json)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
-    override fun chatCompletions(request: ChatCompletionRequest): Flow<ChatCompletionChunk> {
+    override fun chatCompletions(
+        request: ChatCompletionRequest,
+        requestOptions: RequestOptions?
+    ): Flow<ChatCompletionChunk> {
         val builder = HttpRequestBuilder().apply {
             method = HttpMethod.Post
             url(path = ApiPath.ChatCompletions)
@@ -36,6 +45,7 @@ internal class ChatApi(private val requester: HttpRequester) : Chat {
                 append(HttpHeaders.CacheControl, "no-cache")
                 append(HttpHeaders.Connection, "keep-alive")
             }
+            requestOptions(requestOptions)
         }
         return flow {
             requester.perform(builder) { response -> streamEventsFrom(response) }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/EmbeddingsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/EmbeddingsApi.kt
@@ -1,28 +1,28 @@
 package com.aallam.openai.client.internal.api
 
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.embedding.EmbeddingRequest
 import com.aallam.openai.api.embedding.EmbeddingResponse
 import com.aallam.openai.client.Embeddings
+import com.aallam.openai.client.internal.extension.requestOptions
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
-import io.ktor.client.call.body
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.client.request.url
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
 
 /**
  * Implementation of [Embeddings].
  */
 internal class EmbeddingsApi(private val requester: HttpRequester) : Embeddings {
 
-    override suspend fun embeddings(request: EmbeddingRequest): EmbeddingResponse {
+    override suspend fun embeddings(request: EmbeddingRequest, requestOptions: RequestOptions?): EmbeddingResponse {
         return requester.perform {
             it.post {
                 url(path = ApiPath.Embeddings)
                 setBody(request)
                 contentType(ContentType.Application.Json)
+                requestOptions(requestOptions)
             }.body()
         }
     }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/FineTuningApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/FineTuningApi.kt
@@ -1,11 +1,13 @@
 package com.aallam.openai.client.internal.api
 
 import com.aallam.openai.api.core.PaginatedList
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.finetuning.FineTuningId
 import com.aallam.openai.api.finetuning.FineTuningJob
 import com.aallam.openai.api.finetuning.FineTuningJobEvent
 import com.aallam.openai.api.finetuning.FineTuningRequest
 import com.aallam.openai.client.FineTuning
+import com.aallam.openai.client.internal.extension.requestOptions
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
 import io.ktor.client.call.*
@@ -14,37 +16,49 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 
 internal class FineTuningApi(private val requester: HttpRequester) : FineTuning {
-    override suspend fun fineTuningJob(request: FineTuningRequest): FineTuningJob {
+    override suspend fun fineTuningJob(request: FineTuningRequest, requestOptions: RequestOptions?): FineTuningJob {
         return requester.perform {
             it.post {
                 url(path = ApiPath.FineTuningJobs)
                 setBody(request)
                 contentType(ContentType.Application.Json)
+                requestOptions(requestOptions)
             }
         }
     }
 
-    override suspend fun fineTuningJobs(after: String?, limit: Int?): PaginatedList<FineTuningJob> {
+    override suspend fun fineTuningJobs(
+        after: String?,
+        limit: Int?,
+        requestOptions: RequestOptions?
+    ): PaginatedList<FineTuningJob> {
         return requester.perform {
             it.get {
                 url(path = ApiPath.FineTuningJobs) {
                     after?.let { value -> parameter("after", value) }
                     limit?.let { value -> parameter("limit", value) }
                 }
+                requestOptions(requestOptions)
             }
         }
     }
 
-    override suspend fun fineTuningJob(id: FineTuningId): FineTuningJob? {
+    override suspend fun fineTuningJob(id: FineTuningId, requestOptions: RequestOptions?): FineTuningJob? {
         val response = requester.perform<HttpResponse> {
-            it.get { url(path = "${ApiPath.FineTuningJobs}/${id.id}") }
+            it.get {
+                url(path = "${ApiPath.FineTuningJobs}/${id.id}")
+                requestOptions(requestOptions)
+            }
         }
         return if (response.status == HttpStatusCode.NotFound) null else response.body()
     }
 
-    override suspend fun cancel(id: FineTuningId): FineTuningJob? {
+    override suspend fun cancel(id: FineTuningId, requestOptions: RequestOptions?): FineTuningJob? {
         val response = requester.perform<HttpResponse> {
-            it.post { url(path = "${ApiPath.FineTuningJobs}/${id.id}/cancel") }
+            it.post {
+                url(path = "${ApiPath.FineTuningJobs}/${id.id}/cancel")
+                requestOptions(requestOptions)
+            }
         }
         return if (response.status == HttpStatusCode.NotFound) null else response.body()
     }
@@ -52,7 +66,8 @@ internal class FineTuningApi(private val requester: HttpRequester) : FineTuning 
     override suspend fun fineTuningEvents(
         id: FineTuningId,
         after: String?,
-        limit: Int?
+        limit: Int?,
+        requestOptions: RequestOptions?
     ): PaginatedList<FineTuningJobEvent> {
         return requester.perform {
             it.get {
@@ -60,6 +75,7 @@ internal class FineTuningApi(private val requester: HttpRequester) : FineTuning 
                     after?.let { value -> parameter("after", value) }
                     limit?.let { value -> parameter("limit", value) }
                 }
+                requestOptions(requestOptions)
             }
         }
     }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ImagesApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ImagesApi.kt
@@ -1,11 +1,13 @@
 package com.aallam.openai.client.internal.api
 
 import com.aallam.openai.api.core.ListResponse
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.image.*
 import com.aallam.openai.api.image.internal.ImageCreationRequest
 import com.aallam.openai.api.image.internal.ImageResponseFormat
 import com.aallam.openai.client.Images
 import com.aallam.openai.client.internal.extension.appendFileSource
+import com.aallam.openai.client.internal.extension.requestOptions
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
 import io.ktor.client.request.*
@@ -14,40 +16,47 @@ import io.ktor.http.*
 
 internal class ImagesApi(private val requester: HttpRequester) : Images {
 
-    override suspend fun imageURL(creation: ImageCreation): List<ImageURL> {
+    override suspend fun imageURL(creation: ImageCreation, requestOptions: RequestOptions?): List<ImageURL> {
         return requester.perform<ListResponse<ImageURL>> {
             it.post {
                 url(path = ApiPath.ImagesGeneration)
                 setBody(creation.toURLRequest())
                 contentType(ContentType.Application.Json)
+                requestOptions(requestOptions)
             }
         }.data
     }
 
-    override suspend fun imageJSON(creation: ImageCreation): List<ImageJSON> {
+    override suspend fun imageJSON(creation: ImageCreation, requestOptions: RequestOptions?): List<ImageJSON> {
         return requester.perform<ListResponse<ImageJSON>> {
             it.post {
                 url(path = ApiPath.ImagesGeneration)
                 setBody(creation.toJSONRequest())
                 contentType(ContentType.Application.Json)
+                requestOptions(requestOptions)
             }
         }.data
     }
 
-    override suspend fun imageURL(edit: ImageEdit): List<ImageURL> {
+    override suspend fun imageURL(edit: ImageEdit, requestOptions: RequestOptions?): List<ImageURL> {
         return requester.perform<ListResponse<ImageURL>> {
             it.submitFormWithBinaryData(
                 url = ApiPath.ImagesEdits,
-                formData = imageEditRequest(edit, ImageResponseFormat.url)
-            )
+                formData = imageEditRequest(edit, ImageResponseFormat.url),
+            ) {
+                requestOptions(requestOptions)
+            }
         }.data
     }
 
-    override suspend fun imageJSON(edit: ImageEdit): List<ImageJSON> {
+    override suspend fun imageJSON(edit: ImageEdit, requestOptions: RequestOptions?): List<ImageJSON> {
         return requester.perform<ListResponse<ImageJSON>> {
             it.submitFormWithBinaryData(
-                url = ApiPath.ImagesEdits, formData = imageEditRequest(edit, ImageResponseFormat.base64Json)
-            )
+                url = ApiPath.ImagesEdits,
+                formData = imageEditRequest(edit, ImageResponseFormat.base64Json),
+            ) {
+                requestOptions(requestOptions)
+            }
         }.data
     }
 
@@ -65,19 +74,25 @@ internal class ImagesApi(private val requester: HttpRequester) : Images {
         edit.model?.let { model -> append(key = "model", value = model.id) }
     }
 
-    override suspend fun imageURL(variation: ImageVariation): List<ImageURL> {
+    override suspend fun imageURL(variation: ImageVariation, requestOptions: RequestOptions?): List<ImageURL> {
         return requester.perform<ListResponse<ImageURL>> {
             it.submitFormWithBinaryData(
-                url = ApiPath.ImagesVariants, formData = imageVariantRequest(variation, ImageResponseFormat.url)
-            )
+                url = ApiPath.ImagesVariants,
+                formData = imageVariantRequest(variation, ImageResponseFormat.url),
+            ) {
+                requestOptions(requestOptions)
+            }
         }.data
     }
 
-    override suspend fun imageJSON(variation: ImageVariation): List<ImageJSON> {
+    override suspend fun imageJSON(variation: ImageVariation, requestOptions: RequestOptions?): List<ImageJSON> {
         return requester.perform<ListResponse<ImageJSON>> {
             it.submitFormWithBinaryData(
-                url = ApiPath.ImagesVariants, formData = imageVariantRequest(variation, ImageResponseFormat.base64Json)
-            )
+                url = ApiPath.ImagesVariants,
+                formData = imageVariantRequest(variation, ImageResponseFormat.base64Json),
+            ) {
+                requestOptions(requestOptions)
+            }
         }.data
     }
 

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/MessagesApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/MessagesApi.kt
@@ -1,6 +1,7 @@
 package com.aallam.openai.client.internal.api
 
 import com.aallam.openai.api.core.PaginatedList
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.core.SortOrder
 import com.aallam.openai.api.file.FileId
 import com.aallam.openai.api.message.Message
@@ -10,6 +11,7 @@ import com.aallam.openai.api.message.MessageRequest
 import com.aallam.openai.api.thread.ThreadId
 import com.aallam.openai.client.Messages
 import com.aallam.openai.client.internal.extension.beta
+import com.aallam.openai.client.internal.extension.requestOptions
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
 import io.ktor.client.call.*
@@ -17,27 +19,38 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 
 internal class MessagesApi(val requester: HttpRequester) : Messages {
-    override suspend fun message(threadId: ThreadId, request: MessageRequest): Message {
+    override suspend fun message(
+        threadId: ThreadId,
+        request: MessageRequest,
+        requestOptions: RequestOptions?
+    ): Message {
         return requester.perform {
             it.post {
                 url(path = "${ApiPath.Threads}/${threadId.id}/messages")
                 setBody(request)
                 contentType(ContentType.Application.Json)
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
-    override suspend fun message(threadId: ThreadId, messageId: MessageId): Message {
+    override suspend fun message(threadId: ThreadId, messageId: MessageId, requestOptions: RequestOptions?): Message {
         return requester.perform {
             it.get {
                 url(path = "${ApiPath.Threads}/${threadId.id}/messages/${messageId.id}")
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
-    override suspend fun message(threadId: ThreadId, messageId: MessageId, metadata: Map<String, String>?): Message {
+    override suspend fun message(
+        threadId: ThreadId,
+        messageId: MessageId,
+        metadata: Map<String, String>?,
+        requestOptions: RequestOptions?
+    ): Message {
         return requester.perform {
             it.post {
                 url(path = "${ApiPath.Threads}/${threadId.id}/messages/${messageId.id}")
@@ -46,6 +59,7 @@ internal class MessagesApi(val requester: HttpRequester) : Messages {
                     contentType(ContentType.Application.Json)
                 }
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
@@ -55,7 +69,8 @@ internal class MessagesApi(val requester: HttpRequester) : Messages {
         limit: Int?,
         order: SortOrder?,
         after: MessageId?,
-        before: MessageId?
+        before: MessageId?,
+        requestOptions: RequestOptions?
     ): PaginatedList<Message> {
         return requester.perform {
             it.get {
@@ -66,15 +81,22 @@ internal class MessagesApi(val requester: HttpRequester) : Messages {
                     after?.let { value -> parameter("after", value.id) }
                 }
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
-    override suspend fun messageFile(threadId: ThreadId, messageId: MessageId, fileId: FileId): MessageFile {
+    override suspend fun messageFile(
+        threadId: ThreadId,
+        messageId: MessageId,
+        fileId: FileId,
+        requestOptions: RequestOptions?
+    ): MessageFile {
         return requester.perform {
             it.get {
                 url(path = "${ApiPath.Threads}/${threadId.id}/messages/${messageId.id}/files/${fileId.id}")
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
@@ -85,7 +107,8 @@ internal class MessagesApi(val requester: HttpRequester) : Messages {
         limit: Int?,
         order: SortOrder?,
         after: FileId?,
-        before: FileId?
+        before: FileId?,
+        requestOptions: RequestOptions?
     ): PaginatedList<MessageFile> {
         return requester.perform {
             it.get {
@@ -96,6 +119,7 @@ internal class MessagesApi(val requester: HttpRequester) : Messages {
                     after?.let { value -> parameter("after", value.id) }
                 }
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ModelsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ModelsApi.kt
@@ -1,9 +1,11 @@
 package com.aallam.openai.client.internal.api
 
 import com.aallam.openai.api.core.ListResponse
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.model.Model
 import com.aallam.openai.api.model.ModelId
 import com.aallam.openai.client.Models
+import com.aallam.openai.client.internal.extension.requestOptions
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
 import io.ktor.client.request.*
@@ -14,17 +16,21 @@ import io.ktor.http.*
  */
 internal class ModelsApi(private val requester: HttpRequester) : Models {
 
-    override suspend fun models(): List<Model> {
+    override suspend fun models(requestOptions: RequestOptions?): List<Model> {
         return requester.perform<ListResponse<Model>> {
-            it.get { url(path = ApiPath.Models) }
+            it.get {
+                url(path = ApiPath.Models)
+                requestOptions(requestOptions)
+            }
         }.data
     }
 
-    override suspend fun model(modelId: ModelId): Model {
+    override suspend fun model(modelId: ModelId, requestOptions: RequestOptions?): Model {
         return requester.perform {
             it.get {
                 url(path = "${ApiPath.Models}/${modelId.id}")
                 contentType(ContentType.Application.Json)
+                requestOptions(requestOptions)
             }
         }
     }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ModerationsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ModerationsApi.kt
@@ -1,8 +1,10 @@
 package com.aallam.openai.client.internal.api
 
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.moderation.ModerationRequest
 import com.aallam.openai.api.moderation.TextModeration
 import com.aallam.openai.client.Moderations
+import com.aallam.openai.client.internal.extension.requestOptions
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
 import io.ktor.client.call.*
@@ -14,12 +16,13 @@ import io.ktor.http.*
  */
 internal class ModerationsApi(private val requester: HttpRequester) : Moderations {
 
-    override suspend fun moderations(request: ModerationRequest): TextModeration {
+    override suspend fun moderations(request: ModerationRequest, requestOptions: RequestOptions?): TextModeration {
         return requester.perform {
             it.post {
                 url(path = ApiPath.Moderations)
                 setBody(request)
                 contentType(ContentType.Application.Json)
+                requestOptions(requestOptions)
             }.body()
         }
     }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/RunsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/RunsApi.kt
@@ -1,11 +1,13 @@
 package com.aallam.openai.client.internal.api
 
 import com.aallam.openai.api.core.PaginatedList
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.core.SortOrder
 import com.aallam.openai.api.run.*
 import com.aallam.openai.api.thread.ThreadId
 import com.aallam.openai.client.Runs
 import com.aallam.openai.client.internal.extension.beta
+import com.aallam.openai.client.internal.extension.requestOptions
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
 import io.ktor.client.call.*
@@ -13,27 +15,34 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 
 internal class RunsApi(val requester: HttpRequester) : Runs {
-    override suspend fun createRun(threadId: ThreadId, request: RunRequest): Run {
+    override suspend fun createRun(threadId: ThreadId, request: RunRequest, requestOptions: RequestOptions?): Run {
         return requester.perform {
             it.post {
                 url(path = "${ApiPath.Threads}/${threadId.id}/runs")
                 setBody(request)
                 contentType(ContentType.Application.Json)
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
-    override suspend fun getRun(threadId: ThreadId, runId: RunId): Run {
+    override suspend fun getRun(threadId: ThreadId, runId: RunId, requestOptions: RequestOptions?): Run {
         return requester.perform {
             it.get {
                 url(path = "${ApiPath.Threads}/${threadId.id}/runs/${runId.id}")
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
-    override suspend fun updateRun(threadId: ThreadId, runId: RunId, metadata: Map<String, String>?): Run {
+    override suspend fun updateRun(
+        threadId: ThreadId,
+        runId: RunId,
+        metadata: Map<String, String>?,
+        requestOptions: RequestOptions?
+    ): Run {
         return requester.perform {
             it.post {
                 url(path = "${ApiPath.Threads}/${threadId.id}/runs/${runId.id}")
@@ -42,6 +51,7 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
                     contentType(ContentType.Application.Json)
                 }
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
@@ -51,7 +61,8 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
         limit: Int?,
         order: SortOrder?,
         after: RunId?,
-        before: RunId?
+        before: RunId?,
+        requestOptions: RequestOptions?
     ): PaginatedList<Run> {
         return requester.perform {
             it.get {
@@ -62,46 +73,61 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
                     before?.let { parameter("before", it.id) }
                 }
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
-    override suspend fun submitToolOutput(threadId: ThreadId, runId: RunId, output: List<ToolOutput>): Run {
+    override suspend fun submitToolOutput(
+        threadId: ThreadId,
+        runId: RunId,
+        output: List<ToolOutput>,
+        requestOptions: RequestOptions?
+    ): Run {
         return requester.perform {
             it.post {
                 url(path = "${ApiPath.Threads}/${threadId.id}/runs/${runId.id}/submit_tool_outputs")
                 setBody(mapOf("tool_outputs" to output))
                 contentType(ContentType.Application.Json)
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
-    override suspend fun cancel(threadId: ThreadId, runId: RunId): Run {
+    override suspend fun cancel(threadId: ThreadId, runId: RunId, requestOptions: RequestOptions?): Run {
         return requester.perform {
             it.post {
                 url(path = "${ApiPath.Threads}/${threadId.id}/runs/${runId.id}/cancel")
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
-    override suspend fun createThreadRun(request: ThreadRunRequest): Run {
+    override suspend fun createThreadRun(request: ThreadRunRequest, requestOptions: RequestOptions?): Run {
         return requester.perform {
             it.post {
                 url(path = "${ApiPath.Threads}/runs")
                 setBody(request)
                 contentType(ContentType.Application.Json)
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
-    override suspend fun runStep(threadId: ThreadId, runId: RunId, stepId: RunStepId): RunStep {
+    override suspend fun runStep(
+        threadId: ThreadId,
+        runId: RunId,
+        stepId: RunStepId,
+        requestOptions: RequestOptions?
+    ): RunStep {
         return requester.perform {
             it.get {
                 url(path = "${ApiPath.Threads}/${threadId.id}/runs/${runId.id}/steps/${stepId.id}")
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
@@ -112,7 +138,8 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
         limit: Int?,
         order: SortOrder?,
         after: RunStepId?,
-        before: RunStepId?
+        before: RunStepId?,
+        requestOptions: RequestOptions?
     ): PaginatedList<RunStep> {
         return requester.perform {
             it.get {
@@ -123,6 +150,7 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
                     before?.let { parameter("before", it.id) }
                 }
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ThreadsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ThreadsApi.kt
@@ -2,12 +2,14 @@ package com.aallam.openai.client.internal.api
 
 import com.aallam.openai.api.BetaOpenAI
 import com.aallam.openai.api.core.DeleteResponse
+import com.aallam.openai.api.core.RequestOptions
 import com.aallam.openai.api.exception.OpenAIAPIException
 import com.aallam.openai.api.thread.Thread
 import com.aallam.openai.api.thread.ThreadId
 import com.aallam.openai.api.thread.ThreadRequest
 import com.aallam.openai.client.Threads
 import com.aallam.openai.client.internal.extension.beta
+import com.aallam.openai.client.internal.extension.requestOptions
 import com.aallam.openai.client.internal.http.HttpRequester
 import com.aallam.openai.client.internal.http.perform
 import io.ktor.client.call.*
@@ -21,7 +23,7 @@ import kotlinx.serialization.json.putJsonObject
 internal class ThreadsApi(val requester: HttpRequester) : Threads {
 
     @BetaOpenAI
-    override suspend fun thread(request: ThreadRequest?): Thread {
+    override suspend fun thread(request: ThreadRequest?, requestOptions: RequestOptions?): Thread {
         return requester.perform {
             it.post {
                 url(path = ApiPath.Threads)
@@ -30,17 +32,19 @@ internal class ThreadsApi(val requester: HttpRequester) : Threads {
                     contentType(ContentType.Application.Json)
                 }
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
     @BetaOpenAI
-    override suspend fun thread(id: ThreadId): Thread? {
+    override suspend fun thread(id: ThreadId, requestOptions: RequestOptions?): Thread? {
         try {
             return requester.perform<HttpResponse> {
                 it.get {
                     url(path = "${ApiPath.Threads}/${id.id}")
                     beta("assistants", 1)
+                    requestOptions(requestOptions)
                 }
             }.body()
         } catch (e: OpenAIAPIException) {
@@ -50,7 +54,7 @@ internal class ThreadsApi(val requester: HttpRequester) : Threads {
     }
 
     @BetaOpenAI
-    override suspend fun thread(id: ThreadId, metadata: Map<String, String>): Thread {
+    override suspend fun thread(id: ThreadId, metadata: Map<String, String>, requestOptions: RequestOptions?): Thread {
         val request = buildJsonObject {
             putJsonObject("metadata") {
                 metadata.forEach { (key, value) ->
@@ -64,16 +68,18 @@ internal class ThreadsApi(val requester: HttpRequester) : Threads {
                 setBody(request)
                 contentType(ContentType.Application.Json)
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }.body()
         }
     }
 
     @BetaOpenAI
-    override suspend fun delete(id: ThreadId): Boolean {
+    override suspend fun delete(id: ThreadId, requestOptions: RequestOptions?): Boolean {
         val response = requester.perform<HttpResponse> {
             it.delete {
                 url(path = "${ApiPath.Threads}/${id.id}")
                 beta("assistants", 1)
+                requestOptions(requestOptions)
             }
         }
         return when (response.status) {

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/extension/HttpRequestBuilder.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/extension/HttpRequestBuilder.kt
@@ -1,0 +1,21 @@
+package com.aallam.openai.client.internal.extension
+
+import com.aallam.openai.api.core.RequestOptions
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+
+/**
+ * Apply request options to the request builder.
+ */
+internal fun HttpRequestBuilder.requestOptions(requestOptions: RequestOptions? = null) {
+    if (requestOptions == null) return
+    requestOptions.headers.forEach { (key, value) -> headers.append(key, value) }
+    requestOptions.urlParameters.forEach { (key, value) -> url.parameters.append(key, value) }
+    requestOptions.timeout?.let { timeout ->
+        timeout {
+            timeout.connect?.let { connectTimeout -> connectTimeoutMillis = connectTimeout.inWholeMilliseconds }
+            timeout.request?.let { requestTimeout -> requestTimeoutMillis = requestTimeout.inWholeMilliseconds }
+            timeout.socket?.let { socketTimeout -> socketTimeoutMillis = socketTimeout.inWholeMilliseconds }
+        }
+    }
+}

--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/misc/TestRequestOptions.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/misc/TestRequestOptions.kt
@@ -1,0 +1,35 @@
+package com.aallam.openai.client.misc
+
+import com.aallam.openai.api.core.RequestOptions
+import com.aallam.openai.client.OpenAI
+import com.aallam.openai.client.token
+import io.ktor.client.request.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TestRequestOptions {
+
+    @Test
+    fun test() = runTest {
+        val key = "key"
+        val requestOptions = RequestOptions(
+            headers = mapOf(key to "valueB"),
+        )
+        var requestHeaders: Map<String, String>? = null
+        val client = OpenAI(
+            token = token,
+            headers = mapOf(key to "valueA"),
+            httpClientConfig = {
+                install("RequestInterceptor") {
+                    requestPipeline.intercept(HttpRequestPipeline.Before) {
+                        requestHeaders = context.headers.entries().associate { it.key to it.value.first() }
+                    }
+                }
+            }
+        )
+
+        client.models(requestOptions = requestOptions)
+        assertEquals(requestHeaders?.get(key), requestOptions.headers[key])
+    }
+}

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/core/RequestOptions.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/core/RequestOptions.kt
@@ -1,0 +1,16 @@
+package com.aallam.openai.api.core
+
+import com.aallam.openai.api.http.Timeout
+
+/**
+ * Represents options for configuring a request to an endpoint.
+ *
+ * @property headers A mutable map of header names to their respective values to be sent with the request.
+ * @property urlParameters A mutable map of URL parameter names to their respective values to be appended to the request URL.
+ * @property timeout Http operations timeouts.
+ */
+public data class RequestOptions(
+    public val headers: Map<String, String> = emptyMap(),
+    public val urlParameters: Map<String, String> = emptyMap(),
+    public val timeout: Timeout? = null,
+)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #295 

## Describe your change

Add `RequestOptions` to all non-deprecated methods.

## What problem is this fixing?

This adds the capability to override headers, URL parameters, and timeouts on a per-request basis.