### PR TITLE
Add embedding dimensions request field

### DIFF
--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestEmbeddings.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestEmbeddings.kt
@@ -24,6 +24,20 @@ class TestEmbeddings : TestOpenAI() {
     }
 
     @Test
+    fun embeddingDimensions() = test {
+        val response = openAI.embeddings(request = embeddingRequest {
+            model = ModelId("text-embedding-3-small")
+            input = listOf("The food was delicious and the waiter...")
+            dimensions = 1024
+        })
+        assertTrue { response.embeddings.isNotEmpty() }
+        val embedding = response.embeddings.first()
+        assertTrue { embedding.embedding.isNotEmpty() }
+        assertEquals(1024, embedding.embedding.size)
+        assertEquals(0, embedding.index)
+    }
+
+    @Test
     fun similarityEqual() = test {
         val embedding1 = Embedding(embedding = listOf(1.0, 2.0, 3.0, 4.0), index = 0)
         val embedding2 = Embedding(embedding = listOf(1.0, 2.0, 3.0, 4.0), index = 0)

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/embedding/EmbeddingRequest.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/embedding/EmbeddingRequest.kt
@@ -27,6 +27,13 @@ public class EmbeddingRequest(
     @SerialName("input") public val input: List<String>,
 
     /**
+     * The number of dimensions the resulting output embeddings should have.
+     *
+     * Only supported in text-embedding-3 and later models.
+     */
+    @SerialName("dimensions") public val dimensions: Int? = null,
+
+    /**
      * A unique identifier representing your end-user, which will help OpenAI to monitor and detect abuse.
      */
     @SerialName("user") public val user: String? = null,
@@ -60,6 +67,13 @@ public class EmbeddingRequestBuilder {
     public var input: List<String>? = null
 
     /**
+     * The number of dimensions the resulting output embeddings should have.
+     *
+     * Only supported in text-embedding-3 and later models.
+     */
+    public var dimensions: Int? = null
+
+    /**
      * A unique identifier representing your end-user, which will help OpenAI to monitor and detect abuse.
      */
     public var user: String? = null
@@ -70,6 +84,7 @@ public class EmbeddingRequestBuilder {
     public fun build(): EmbeddingRequest = EmbeddingRequest(
         model = requireNotNull(model) { "model is required" },
         input = requireNotNull(input) { "input is required" },
+        dimensions = dimensions,
         user = user
     )
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | None
## Describe your change

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

This adds the `dimensions` request field available when creating embeddings with the new `text-embedding-3` models.

https://platform.openai.com/docs/api-reference/embeddings/create?lang=curl

## What problem is this fixing?

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->

The field was missing and i wanted to use it :) 