### PR TITLE
Fix issue https://github.com/aallam/openai-kotlin/issues/320 (Invalid value: 'image'. Supported values are: 'text' and 'image_url')

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatMessage.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatMessage.kt
@@ -211,7 +211,7 @@ public data class TextPart(@SerialName("text") val text: String) : ContentPart
  * @param imageUrl the image url.
  */
 @Serializable
-@SerialName("image")
+@SerialName("image_url")
 public data class ImagePart(
     @SerialName("image_url") val imageUrl: ImageURL,
 ) : ContentPart {


### PR DESCRIPTION
This fixes issue #320 invalid value: 'image'. Supported values are: 'text' and 'image_url' (https://github.com/aallam/openai-kotlin/issues/320)

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    
| BC breaks?        | no
| Related Issue     | Fix #320

## Describe your change

This fix correct the wrong contentpart type "Image" to the correct one "image_url"

## What problem is this fixing?

This problem fixes issue #320 