### PR TITLE
untested fix: make .models() call not crash if created or owned_by are missing in some endpoints (openrouter)

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/model/Model.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/model/Model.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class Model(
     @SerialName("id") public val id: ModelId,
-    @SerialName("created") public val created: Long,
-    @SerialName("owned_by") public val ownedBy: String,
+    @SerialName("created") public val created: Long? = null,
+    @SerialName("owned_by") public val ownedBy: String? = null,
     @SerialName("permission") public val permission: List<ModelPermission>? = null,
 )


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | not sure
| Related Issue     | Fix #331

## Describe your change

This change was suggested by GPT-4 as I don't know Kotlin. Moreover I don't know how openai-kotlin was engineered so I don't know if that breaks backward compatibility or if some parts of the lib rely on the fields `created` and `owned-by` to exist.

## What problem is this fixing?

In issue #331 I reported that listing models fails with the endpoint of openrouter because those two keys are missing. To me supporting openrouter.ai would really be awesome because they support [many many many models](https://openrouter.ai/docs#models) including from OpenAI, Anthropic, Cohere, Mistral, Google, etc. So even the bare minimum amount of compatibility (listing models, calling completion etc) would go a really long way in terms of how much flexibility that would give to your lib!


Edit: here's a typical output from `curl https://openrouter.ai/api/v1/models |jq`:
```
    {
      "id": "cohere/command-r-plus",
      "name": "Cohere: Command R+",
      "description": "Command R+ is a new, 104B-parameter LLM from Cohere. It's useful for roleplay, general consumer usecases, and Retrieval Augmented Generation (RAG).\n\nIt offers multilingual support for ten key languages to facilitate global business operations. See benchmarks and the launch post [here](https://txt.cohere.com/command-r-plus-microsoft-azure/).\n\nUse of this model is subject to Cohere's [Acceptable Use Policy](https://docs.cohere.com/docs/c4ai-acceptable-use-policy).",
      "pricing": {
        "prompt": "0.000003",
        "completion": "0.000015",
        "image": "0",
        "request": "0"
      },
      "context_length": 128000,
      "architecture": {
        "modality": "text",
        "tokenizer": "Cohere",
        "instruct_type": null
      },
      "top_provider": {
        "max_completion_tokens": 4000,
        "is_moderated": false
      },
      "per_request_limits": null
    }
```

So indeed the owned_by and created fields don't exist, but I don't know if those extra fields like "pricing" would cause a crash or not.