### PR TITLE
Assistant.name is nullable

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/assistant/Assistant.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/assistant/Assistant.kt
@@ -21,7 +21,7 @@ public data class Assistant(
     /**
      * The name of the assistant. The maximum length is 256 characters.
      */
-    @SerialName("name") public val name: String,
+    @SerialName("name") public val name: String? = null,
 
     /**
      * The description of the assistant. The maximum length is 512 characters.


### PR DESCRIPTION
Trying to list assistants currently fails if one of them has no name.

![image](https://github.com/aallam/openai-kotlin/assets/2620907/d4d6180b-0f11-46d6-bea4-6791bb1a4e82)

https://platform.openai.com/docs/api-reference/assistants/createAssistant#assistants-createassistant-name