### PR TITLE
fix(runs): beta-v2 hotfix - Runs need v2 version to use gpt-4o

### DIFF
--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/RunsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/RunsApi.kt
@@ -21,7 +21,7 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
                 url(path = "${ApiPath.Threads}/${threadId.id}/runs")
                 setBody(request)
                 contentType(ContentType.Application.Json)
-                beta("assistants", 1)
+                beta("assistants", 2)
                 requestOptions(requestOptions)
             }.body()
         }
@@ -31,7 +31,7 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
         return requester.perform {
             it.get {
                 url(path = "${ApiPath.Threads}/${threadId.id}/runs/${runId.id}")
-                beta("assistants", 1)
+                beta("assistants", 2)
                 requestOptions(requestOptions)
             }.body()
         }
@@ -50,7 +50,7 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
                     setBody(mapOf("metadata" to meta))
                     contentType(ContentType.Application.Json)
                 }
-                beta("assistants", 1)
+                beta("assistants", 2)
                 requestOptions(requestOptions)
             }.body()
         }
@@ -72,7 +72,7 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
                     after?.let { parameter("after", it.id) }
                     before?.let { parameter("before", it.id) }
                 }
-                beta("assistants", 1)
+                beta("assistants", 2)
                 requestOptions(requestOptions)
             }.body()
         }
@@ -89,7 +89,7 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
                 url(path = "${ApiPath.Threads}/${threadId.id}/runs/${runId.id}/submit_tool_outputs")
                 setBody(mapOf("tool_outputs" to output))
                 contentType(ContentType.Application.Json)
-                beta("assistants", 1)
+                beta("assistants", 2)
                 requestOptions(requestOptions)
             }.body()
         }
@@ -99,7 +99,7 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
         return requester.perform {
             it.post {
                 url(path = "${ApiPath.Threads}/${threadId.id}/runs/${runId.id}/cancel")
-                beta("assistants", 1)
+                beta("assistants", 2)
                 requestOptions(requestOptions)
             }.body()
         }
@@ -111,7 +111,7 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
                 url(path = "${ApiPath.Threads}/runs")
                 setBody(request)
                 contentType(ContentType.Application.Json)
-                beta("assistants", 1)
+                beta("assistants", 2)
                 requestOptions(requestOptions)
             }.body()
         }
@@ -126,7 +126,7 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
         return requester.perform {
             it.get {
                 url(path = "${ApiPath.Threads}/${threadId.id}/runs/${runId.id}/steps/${stepId.id}")
-                beta("assistants", 1)
+                beta("assistants", 2)
                 requestOptions(requestOptions)
             }.body()
         }
@@ -149,7 +149,7 @@ internal class RunsApi(val requester: HttpRequester) : Runs {
                     after?.let { parameter("after", it.id) }
                     before?.let { parameter("before", it.id) }
                 }
-                beta("assistants", 1)
+                beta("assistants", 2)
                 requestOptions(requestOptions)
             }.body()
         }

--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestRuns.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestRuns.kt
@@ -3,10 +3,15 @@ package com.aallam.openai.client
 import com.aallam.openai.api.assistant.AssistantTool
 import com.aallam.openai.api.assistant.assistantRequest
 import com.aallam.openai.api.core.PaginatedList
+import com.aallam.openai.api.core.Role
+import com.aallam.openai.api.message.MessageRequest
 import com.aallam.openai.api.model.ModelId
 import com.aallam.openai.api.run.RunRequest
 import com.aallam.openai.api.run.RunStep
 import com.aallam.openai.api.run.ThreadRunRequest
+import com.aallam.openai.api.thread.ThreadId
+import com.aallam.openai.api.thread.ThreadMessage
+import com.aallam.openai.api.thread.ThreadRequest
 import com.aallam.openai.client.internal.JsonLenient
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,11 +24,20 @@ class TestRuns : TestOpenAI() {
             request = assistantRequest {
                 name = "Math Tutor"
                 tools = listOf(AssistantTool.CodeInterpreter)
-                model = ModelId("gpt-4")
+                model = ModelId("gpt-4o")
             }
         )
         val thread = openAI.thread()
         val request = RunRequest(assistantId = assistant.id)
+        openAI.message(
+            threadId = thread.id,
+            request = MessageRequest(
+                role = Role.User,
+                content = "solve me 1 + 1",
+                metadata = mapOf(),
+            ),
+            requestOptions = null,
+        )
         val run = openAI.createRun(threadId = thread.id, request = request)
         assertEquals(thread.id, run.threadId)
 
@@ -32,8 +46,6 @@ class TestRuns : TestOpenAI() {
 
         val runs = openAI.runs(threadId = thread.id)
         assertEquals(1, runs.size)
-
-        openAI.cancel(threadId = thread.id, runId = run.id)
     }
 
     @Test
@@ -42,10 +54,20 @@ class TestRuns : TestOpenAI() {
             request = assistantRequest {
                 name = "Math Tutor"
                 tools = listOf(AssistantTool.CodeInterpreter)
-                model = ModelId("gpt-4")
+                model = ModelId("gpt-4o")
             }
         )
-        val request = ThreadRunRequest(assistantId = assistant.id)
+        val request = ThreadRunRequest(
+            thread = ThreadRequest(
+                listOf(
+                    ThreadMessage(
+                        role = Role.User,
+                        content = "solve 1 + 2",
+                    )
+                )
+            ),
+            assistantId = assistant.id,
+        )
         val run = openAI.createThreadRun(request)
         assertEquals(assistant.id, run.assistantId)
 

--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestRuns.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestRuns.kt
@@ -9,7 +9,6 @@ import com.aallam.openai.api.model.ModelId
 import com.aallam.openai.api.run.RunRequest
 import com.aallam.openai.api.run.RunStep
 import com.aallam.openai.api.run.ThreadRunRequest
-import com.aallam.openai.api.thread.ThreadId
 import com.aallam.openai.api.thread.ThreadMessage
 import com.aallam.openai.api.thread.ThreadRequest
 import com.aallam.openai.client.internal.JsonLenient


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #356   <!-- will close issue automatically, if any -->

## Describe your change
- updated beta version for Runs API too
- Requesting parameters haven't changed
- modified test of TestRun to use gpt-4o / it also needed message to make a run from v2, so I added test message too
<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

## What problem is this fixing?
Using 'run' api for gpt-4o model also depends on beta version-v2
<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->