### PR TITLE
Default `ChatChunk.finishReason` to null

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatChunk.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatChunk.kt
@@ -33,5 +33,5 @@ public data class ChatChunk(
     /**
      * The reason why OpenAI stopped generating.
      */
-    @SerialName("finish_reason") public val finishReason: FinishReason?,
+    @SerialName("finish_reason") public val finishReason: FinishReason? = null,
 )


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | 

## Describe your change

Default `ChatChunk.finishReason` to null. This should allow us to support more service providers.

## What problem is this fixing?

Currently, `ChatChunk.finishReason` is declared as nullable but does not have a default value. Serialization complains that the field is missing.

```
Caused by: [CIRCULAR REFERENCE: com.aallam.openai.api.exception.OpenAIHttpException: Field 'finish_reason' is required for type with serial name 'com.aallam.openai.api.chat.ChatChunk', but it was missing at path: $.choices[0]]
```
