### PR TITLE
Add instanceId field to ChatCompletionRequest

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionRequest.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionRequest.kt
@@ -158,6 +158,11 @@ public class ChatCompletionRequest(
      * each with an associated log probability. logprobs must be set to true if this parameter is used.
      */
     @SerialName("top_logprobs") public val topLogprobs: Int? = null,
+
+    /**
+     * A unique identifier representing the Multi LORA reserved instance.
+     */
+    @SerialName("instance_id") public val instanceId: String? = null,
 )
 
 /**
@@ -307,6 +312,11 @@ public class ChatCompletionRequestBuilder {
     public var topLogprobs: Int? = null
 
     /**
+     * A unique identifier representing the Multi LORA reserved instance.
+     */
+    public var instanceId: String? = null
+
+    /**
      * The messages to generate chat completions for.
      */
     public fun messages(block: ChatMessagesBuilder.() -> Unit) {
@@ -349,7 +359,8 @@ public class ChatCompletionRequestBuilder {
         toolChoice = toolChoice,
         tools = tools,
         logprobs = logprobs,
-        topLogprobs = topLogprobs
+        topLogprobs = topLogprobs,
+        instanceId = instanceId,
     )
 }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | 

## Describe your change
Adds an instanceID field in ChatCompletionRequest which can be used to target a specific multi LoRA reserved instance. 

Sample curl command:
`curl -X POST https://api.openai.com/v1/chat/completions -H "Authorization: Bearer $OPENAI_API_KEY" -d '{"messages": [{"role":"user", "content": "how do i tie my shoes?"}], "model":"gpt-3.5-turbo-1106", "instance_id": "gpt-3.5-turbo-1106-instance"}' -H 'Content-Type: application/json'`

## What problem is this fixing?

There's no option currently to target a specific instance/fleet in OpenAI, especially if using multi LoRA.