### PR TITLE
fix 'quote' to optional field for openai compatibility assistant on FileCitation

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/message/MessageContent.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/message/MessageContent.kt
@@ -107,7 +107,7 @@ public data class FileCitation(
     /**
      * The specific quote in the file
      */
-    @SerialName("quote") val quote: String? = "",
+    @SerialName("quote") val quote: String? = null,
 )
 
 /**

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/message/MessageContent.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/message/MessageContent.kt
@@ -107,7 +107,7 @@ public data class FileCitation(
     /**
      * The specific quote in the file
      */
-    @SerialName("quote") val quote: String,
+    @SerialName("quote") val quote: String? = "",
 )
 
 /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no   
| BC breaks?        | no
| Related Issue     | no

## Describe your change

Change field 'quote' on com.aallam.openai.api.message.FileCitation nullable with no-value

## What problem is this fixing?

In openai API for assistants module, api can't return type quote 
![image](https://github.com/aallam/openai-kotlin/assets/17503825/42e19131-9144-4a09-ab5d-45707c8bcaec)

Tested and works !
