### PR TITLE
feat(assistants): add `attachments.fileId` field to `MessageRequest`

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/message/Attachment.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/message/Attachment.kt
@@ -1,0 +1,16 @@
+package com.aallam.openai.api.message
+
+import com.aallam.openai.api.file.FileId
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * References an Attachment in the message request.
+ */
+@Serializable
+public data class Attachment(
+    /**
+     * The ID of the file to attach to the message.
+     */
+    @SerialName("file_id") val fileId: FileId
+)

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/message/MessageRequest.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/message/MessageRequest.kt
@@ -2,7 +2,6 @@ package com.aallam.openai.api.message
 
 import com.aallam.openai.api.BetaOpenAI
 import com.aallam.openai.api.core.Role
-import com.aallam.openai.api.file.FileId
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -21,6 +20,11 @@ public class MessageRequest(
      * The content of the message.
      */
     @SerialName("content") public val content: String,
+
+    /**
+     * A list of files attached to the message.
+     */
+    @SerialName("attachments") public val attachments: List<Attachment>? = null,
 
     /**
      * Set of 16 key-value pairs that can be attached to an object.
@@ -53,6 +57,11 @@ public class MessageRequestBuilder {
     public var content: String? = null
 
     /**
+     * A list of files attached to the message.
+     */
+    public var attachments: List<Attachment>? = null
+
+    /**
      * Set of 16 key-value pairs that can be attached to an object.
      * This can be useful for storing additional information about the object in a structured format.
      * Keys can be a maximum of 64 characters long, and values can be a maximum of 512 characters long.
@@ -62,6 +71,7 @@ public class MessageRequestBuilder {
     public fun build(): MessageRequest = MessageRequest(
         role = requireNotNull(role) { "role is required" },
         content = requireNotNull(content) { "content is required" },
+        attachments = attachments,
         metadata = metadata
     )
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes   <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     |

## Describe your change

Adds an optional `attachments.fileId` field in MessageRequest that can be used to specify attachment file in message API.
You can check [here](https://platform.openai.com/docs/api-reference/messages/createMessage#messages-createmessage-attachments) for its API reference.

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

## What problem is this fixing? 
currently not able to specify attachment file using [create message](https://platform.openai.com/docs/api-reference/messages/createMessage) API.

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->