### PR TITLE
fix #368 serialization exception while retrieving thread messages

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/message/MessageContent.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/message/MessageContent.kt
@@ -107,7 +107,7 @@ public data class FileCitation(
     /**
      * The specific quote in the file
      */
-    @SerialName("quote") val quote: String,
+    @SerialName("quote") val quote: String? = null,
 )
 
 /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no 
| BC breaks?        | no
| Related Issue     | Fix #368 

## Describe your change

Make `quote` field in FileCitation nullable 

## What problem is this fixing?

Exception in serialization if there is no quote field in response json