### PR TITLE
Make ChatCompletionChunk.created long

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionChunk.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionChunk.kt
@@ -22,7 +22,7 @@ public data class ChatCompletionChunk(
      * The creation time in epoch milliseconds.
      */
     @SerialName("created")
-    public val created: Int,
+    public val created: Long,
 
     /**
      * The model used.


### PR DESCRIPTION
Unix timestamps should be longs.

ChatCompletion.created is Long (https://platform.openai.com/docs/api-reference/chat/object#chat/object-created) but ChatCompletionChunk.created is Int (https://platform.openai.com/docs/api-reference/chat/streaming#chat/streaming-created) even though they hold the same data.