### PR TITLE
Allow specifying JSON schema for chat completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+### Added
+- **chat**: Add support for structured outputs (#397)
+
 ## 4.0.0-beta01
 > Published 27 Oct 2024
 

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatResponseFormat.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatResponseFormat.kt
@@ -2,6 +2,7 @@ package com.aallam.openai.api.chat
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 /**
  * An object specifying the format that the model must output.
@@ -11,9 +12,13 @@ public data class ChatResponseFormat(
     /**
      * Response format type.
      */
-    @SerialName("type") val type: String
-) {
+    @SerialName("type") val type: String,
 
+    /**
+     * Optional JSON schema specification when type is "json_schema"
+     */
+    @SerialName("json_schema") val jsonSchema: JsonSchema? = null
+) {
     public companion object {
         /**
          * JSON mode, which guarantees the message the model generates, is valid JSON.
@@ -24,5 +29,32 @@ public data class ChatResponseFormat(
          * Default text mode.
          */
         public val Text: ChatResponseFormat = ChatResponseFormat(type = "text")
+
+        /**
+         * Creates a JSON schema response format with the specified schema
+         */
+        public fun jsonSchema(schema: JsonSchema): ChatResponseFormat =
+            ChatResponseFormat(type = "json_schema", jsonSchema = schema)
     }
 }
+
+/**
+ * Specification for JSON schema response format
+ */
+@Serializable
+public data class JsonSchema(
+    /**
+     * Optional name for the schema
+     */
+    @SerialName("name") val name: String? = null,
+
+    /**
+     * The JSON schema specification
+     */
+    @SerialName("schema") val schema: JsonObject,
+
+    /**
+     * Whether to enforce strict schema validation
+     */
+    @SerialName("strict") val strict: Boolean = true
+)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | Fix #397 

## Describe your change

Allow specifying JSON schema for chat completions. See the added unit test (jsonSchema in TestChatCompletions) for a simple example of how to use. 

Note: This feature is only available for models 4o and later.


## What problem is this fixing?

OpenAI's API supports specifying JSON schema for recent models. This library does not currently allow the user to specify this, and now it will. 
One benefit is that (as can be seen in the added unit test), you do not have to specify the schema in the messages themselves now.
