### PR TITLE
Feature/assistant-streaming

### DIFF
--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Runs.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/Runs.kt
@@ -6,6 +6,8 @@ import com.aallam.openai.api.core.SortOrder
 import com.aallam.openai.api.core.Status
 import com.aallam.openai.api.run.*
 import com.aallam.openai.api.thread.ThreadId
+import io.ktor.sse.ServerSentEvent
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Represents an execution run on a thread.
@@ -22,6 +24,21 @@ public interface Runs {
      */
     @BetaOpenAI
     public suspend fun createRun(threadId: ThreadId, request: RunRequest, requestOptions: RequestOptions? = null): Run
+
+    /**
+     * Create a run with event streaming.
+     *
+     * @param threadId The ID of the thread to run
+     * @param request request for a run
+     * @param requestOptions request options.
+     * @param block a lambda function that will be called for each event.
+     */
+    @BetaOpenAI
+    public suspend fun createStreamingRun(
+        threadId: ThreadId,
+        request: RunRequest,
+        requestOptions: RequestOptions? = null
+    ) : Flow<AssistantStreamEvent>
 
     /**
      * Retrieves a run.
@@ -93,6 +110,25 @@ public interface Runs {
     ): Run
 
     /**
+     * When a run has the status: [Status.RequiresAction] and required action is [RequiredAction.SubmitToolOutputs],
+     * this endpoint can be used to submit the outputs from the tool calls once they're all completed.
+     * All outputs must be submitted in a single request using event streaming.
+     *
+     * @param threadId the ID of the thread to which this run belongs
+     * @param runId the ID of the run to submit tool outputs for
+     * @param output list of tool outputs to submit
+     * @param requestOptions request options.
+     * @param block a lambda function that will be called for each event.
+     */
+    @BetaOpenAI
+    public suspend fun submitStreamingToolOutput(
+        threadId: ThreadId,
+        runId: RunId,
+        output: List<ToolOutput>,
+        requestOptions: RequestOptions? = null
+    ) : Flow<AssistantStreamEvent>
+
+    /**
      * Cancels a run that is [Status.InProgress].
      *
      * @param threadId the ID of the thread to which this run belongs
@@ -110,6 +146,19 @@ public interface Runs {
      */
     @BetaOpenAI
     public suspend fun createThreadRun(request: ThreadRunRequest, requestOptions: RequestOptions? = null): Run
+
+    /**
+     * Create a thread and run it in one request with event streaming.
+     *
+     * @param request request for a thread run
+     * @param requestOptions request options.
+     * @param block a lambda function that will be called for each event.
+     */
+    @BetaOpenAI
+    public suspend fun createStreamingThreadRun(
+        request: ThreadRunRequest,
+        requestOptions: RequestOptions? = null
+    ) : Flow<AssistantStreamEvent>
 
     /**
      * Retrieves a run step.

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/extension/AssistantStreamEvent.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/extension/AssistantStreamEvent.kt
@@ -1,0 +1,30 @@
+package com.aallam.openai.client.extension
+
+import com.aallam.openai.api.run.AssistantStreamEvent
+import com.aallam.openai.client.internal.JsonLenient
+import kotlinx.serialization.KSerializer
+
+/**
+ * Get the data of the [AssistantStreamEvent] using the provided [serializer] from the corresponding event type.
+ * @param <T> the type of the data.
+ * @throws IllegalStateException if the [AssistantStreamEvent] data is null.
+ * @throws ClassCastException if the [AssistantStreamEvent] data cannot be cast to the provided type.
+ */
+@Suppress("UNCHECKED_CAST")
+public fun <T> AssistantStreamEvent.getData(): T {
+	return type
+		.let { it.serializer as? KSerializer<T> }
+		?.let(::getData)
+		?: throw IllegalStateException("Failed to decode ServerSentEvent: $rawType")
+}
+
+
+/**
+ * Get the data of the [AssistantStreamEvent] using the provided [serializer].
+ * @throws IllegalStateException if the [AssistantStreamEvent] data is null.
+ * @throws ClassCastException if the [AssistantStreamEvent] data cannot be cast to the provided type.
+ */
+public fun <T> AssistantStreamEvent.getData(serializer: KSerializer<T>): T =
+	data
+		?.let { JsonLenient.decodeFromString(serializer, it) }
+		?: throw IllegalStateException("ServerSentEvent data was null: $rawType")

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/extension/ServerSentEvent.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/extension/ServerSentEvent.kt
@@ -1,0 +1,19 @@
+package com.aallam.openai.client.extension
+
+import com.aallam.openai.api.run.AssistantStreamEvent
+import com.aallam.openai.api.run.AssistantStreamEventType
+import com.aallam.openai.client.internal.JsonLenient
+import io.ktor.sse.ServerSentEvent
+import kotlinx.serialization.KSerializer
+
+/**
+ * Convert a [ServerSentEvent] to [AssistantStreamEvent]. Type will be [AssistantStreamEventType.UNKNOWN] if the event is null or unrecognized.
+ */
+internal fun ServerSentEvent.toAssistantStreamEvent() : AssistantStreamEvent =
+	AssistantStreamEvent(
+		event,
+		event
+			?.let(AssistantStreamEventType::fromEvent)
+			?:AssistantStreamEventType.UNKNOWN,
+		data
+	)

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/HttpClient.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/HttpClient.kt
@@ -11,6 +11,7 @@ import io.ktor.client.plugins.auth.*
 import io.ktor.client.plugins.auth.providers.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.logging.*
+import io.ktor.client.plugins.sse.SSE
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.*
 import io.ktor.util.*
@@ -70,6 +71,8 @@ internal fun createHttpClient(config: OpenAIConfig): HttpClient {
             retryIf { _, response -> response.status.value.let { it == 429 } }
             exponentialDelay(config.retry.base, config.retry.maxDelay.inWholeMilliseconds)
         }
+
+        install(SSE)
 
         defaultRequest {
             url(config.host.baseUrl)

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpRequester.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpRequester.kt
@@ -1,9 +1,13 @@
 package com.aallam.openai.client.internal.http
 
+import com.aallam.openai.api.run.AssistantStreamEvent
 import io.ktor.client.*
+import io.ktor.client.plugins.sse.ClientSSESession
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import io.ktor.sse.ServerSentEvent
 import io.ktor.util.reflect.*
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Http request performer.
@@ -14,6 +18,14 @@ internal interface HttpRequester : AutoCloseable {
      * Perform an HTTP request and get a result.
      */
     suspend fun <T : Any> perform(info: TypeInfo, block: suspend (HttpClient) -> HttpResponse): T
+
+    /**
+     * Perform an HTTP request and process emitted server-side events.
+     *
+     */
+    suspend fun performSse(
+        builderBlock: HttpRequestBuilder.() -> Unit
+    ): Flow<AssistantStreamEvent>
 
     /**
      * Perform an HTTP request and get a result.

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/AssistantStreamEvent.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/AssistantStreamEvent.kt
@@ -188,7 +188,7 @@ public enum class AssistantStreamEventType(
     /**
      * Occurs when a message is created.
      */
-    THREAD_MESSAGE_CREATED("thread.message.created", Message::class, RunStep.serializer()),
+    THREAD_MESSAGE_CREATED("thread.message.created", Message::class, Message.serializer()),
 
     /**
      * Occurs when a message moves to an in_progress state.

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/AssistantStreamEvent.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/AssistantStreamEvent.kt
@@ -1,0 +1,251 @@
+package com.aallam.openai.api.run
+
+import com.aallam.openai.api.BetaOpenAI
+import com.aallam.openai.api.core.Role
+import com.aallam.openai.api.message.Message
+import com.aallam.openai.api.message.MessageContent
+import com.aallam.openai.api.message.MessageId
+import com.aallam.openai.api.thread.Thread
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlin.reflect.KClass
+
+/**
+ * Represents an event emitted when streaming a run.
+ * @property rawType the raw string of the event type.
+ * @property type the type of the event or [AssistantStreamEventType.UNKNOWN] if unrecognized.
+ * @property data the string serialized representation of the data for the event.
+ */
+@BetaOpenAI
+@Serializable
+public data class AssistantStreamEvent(
+    @SerialName("rawType") val rawType: String?,
+    @SerialName("type") val type: AssistantStreamEventType,
+    @SerialName("data") val data: String?
+)
+
+/**
+ * Represents a run step delta i.e. any changed fields on a run step during streaming.
+ * @property id the identifier of the run step, which can be referenced in API endpoints.
+ * @property object the object type, which is always thread.run.step.delta.
+ * @property delta the delta containing the fields that have changed on the run step.
+ */
+@BetaOpenAI
+@Serializable
+public data class RunStepDelta(
+    @SerialName("id") val id: RunStepId,
+    @SerialName("object") val `object`: String,
+    @SerialName("delta") val delta: RunStepDeltaData
+)
+
+/**
+ * The delta containing the fields that have changed on the run step.
+ * @property stepDetails the details of the run step.
+ */
+@BetaOpenAI
+@Serializable
+public data class RunStepDeltaData(
+    @SerialName("step_details") val stepDetails: RunStepDetails
+)
+
+/**
+ * Represents a message delta i.e. any changed fields on a message during streaming.
+ * @param id the identifier of the message, which can be referenced in API endpoints.
+ * @param object the object type, which is always thread.message.delta.
+ * @param delta the delta containing the fields that have changed on the message.
+ */
+@BetaOpenAI
+@Serializable
+public data class MessageDelta(
+    @SerialName("id") val id: MessageId,
+    @SerialName("object") val `object`: String,
+    @SerialName("delta") val delta: MessageDeltaData
+)
+
+/**
+ * The delta containing the fields that have changed on the message.
+ * @param role the entity that produced the message. One of user or assistant.
+ * @param content the content of the message in array of text and/or images.
+ */
+@BetaOpenAI
+@Serializable
+public data class MessageDeltaData(
+    @SerialName("role") val role: Role,
+    @SerialName("content") val content: MessageContent
+)
+
+/**
+ * Represents an event type emitted when streaming a Run.
+ * @property event the string representation of event type.
+ * @property dataType the type of the data.
+ * @property serializer the serializer corresponding to the data type.
+ */
+@BetaOpenAI
+@Serializable(with = AssistantStreamEventTypeSerializer::class)
+public enum class AssistantStreamEventType(
+    public val event: String,
+    @Suppress("MemberVisibilityCanBePrivate") public val dataType: KClass<*>,
+    public val serializer: KSerializer<*>
+) {
+
+    /**
+     * Occurs when a new thread is created.
+     */
+    THREAD_CREATED("thread.created", Thread::class, Thread.serializer()),
+
+    /**
+     * Occurs when a new run is created.
+     */
+    THREAD_RUN_CREATED("thread.run.created", Run::class, Run.serializer()),
+
+    /**
+     * Occurs when a run moves to a queued status.
+     */
+    THREAD_RUN_QUEUED("thread.run.queued", Run::class, Run.serializer()),
+
+    /**
+     * Occurs when a run moves to an in_progress status.
+     */
+    THREAD_RUN_IN_PROGRESS("thread.run.in_progress", Run::class, Run.serializer()),
+
+    /**
+     * Occurs when a run moves to a requires_action status.
+     */
+    THREAD_RUN_REQUIRES_ACTION("thread.run.requires_action", Run::class, Run.serializer()),
+
+    /**
+     * Occurs when a run is completed.
+     */
+    THREAD_RUN_COMPLETED("thread.run.completed", Run::class, Run.serializer()),
+
+    /**
+     * Occurs when a run ends with status incomplete.
+     */
+    THREAD_RUN_INCOMPLETE("thread.run.incomplete", Run::class, Run.serializer()),
+
+    /**
+     * Occurs when a run fails.
+     */
+    THREAD_RUN_FAILED("thread.run.failed", Run::class, Run.serializer()),
+
+    /**
+     * Occurs when a run moves to a cancelling status.
+     */
+    THREAD_RUN_CANCELLING("thread.run.cancelling", Run::class, Run.serializer()),
+
+    /**
+     * Occurs when a run is cancelled.
+     */
+    THREAD_RUN_CANCELLED("thread.run.cancelled", Run::class, Run.serializer()),
+
+    /**
+     * Occurs when a run expires.
+     */
+    THREAD_RUN_EXPIRED("thread.run.expired", Run::class, Run.serializer()),
+
+    /**
+     * Occurs when a run step is created.
+     */
+    THREAD_RUN_STEP_CREATED("thread.run.step.created", RunStep::class, RunStep.serializer()),
+
+    /**
+     * Occurs when a run step moves to an in_progress state.
+     */
+    THREAD_RUN_STEP_IN_PROGRESS("thread.run.step.in_progress", RunStep::class, RunStep.serializer()),
+
+    /**
+     * Occurs when parts of a run step are being streamed.
+     */
+    THREAD_RUN_STEP_DELTA("thread.run.step.delta", RunStepDelta::class, RunStepDelta.serializer()),
+
+    /**
+     * Occurs when a run step is completed.
+     */
+    THREAD_RUN_STEP_COMPLETED("thread.run.step.completed", RunStep::class, RunStep.serializer()),
+
+    /**
+     * Occurs when a run step fails.
+     */
+    THREAD_RUN_STEP_FAILED("thread.run.step.failed", RunStep::class, RunStep.serializer()),
+
+    /**
+     * Occurs when a run step is cancelled.
+     */
+    THREAD_RUN_STEP_CANCELLED("thread.run.step.cancelled", RunStep::class, RunStep.serializer()),
+
+    /**
+     * Occurs when a run step expires.
+     */
+    THREAD_RUN_STEP_EXPIRED("thread.run.step.expired", RunStep::class, RunStep.serializer()),
+
+    /**
+     * Occurs when a message is created.
+     */
+    THREAD_MESSAGE_CREATED("thread.message.created", Message::class, RunStep.serializer()),
+
+    /**
+     * Occurs when a message moves to an in_progress state.
+     */
+    THREAD_MESSAGE_IN_PROGRESS("thread.message.in_progress", Message::class, Message.serializer()),
+
+    /**
+     * Occurs when parts of a Message are being streamed.
+     */
+    THREAD_MESSAGE_DELTA("thread.message.delta", MessageDelta::class, MessageDelta.serializer()),
+
+    /**
+     * Occurs when a message is completed.
+     */
+    THREAD_MESSAGE_COMPLETED("thread.message.completed", Message::class, Message.serializer()),
+
+    /**
+     * Occurs when a message ends before it is completed.
+     */
+    THREAD_MESSAGE_INCOMPLETE("thread.message.incomplete", Message::class, Message.serializer()),
+
+    /**
+     * Occurs when an error occurs. This can happen due to an internal server error or a timeout.
+     */
+    ERROR("error", String::class, String.serializer()),
+
+    /**
+     * Occurs when a stream ends.
+     * data is [DONE]
+     */
+    DONE("done", String::class, String.serializer()),
+
+    /**
+     * Occurs when the event type is not recognized
+     */
+    UNKNOWN("unknown", String::class, String.serializer());
+
+    public companion object {
+        public fun fromEvent(event: String): AssistantStreamEventType =
+            entries
+                .find { it.event == event }
+                ?: UNKNOWN
+    }
+}
+
+/**
+ * Custom serializer for [AssistantStreamEventType].
+ */
+@OptIn(BetaOpenAI::class)
+public class AssistantStreamEventTypeSerializer : KSerializer<AssistantStreamEventType> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("AssistantStreamEventType", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): AssistantStreamEventType {
+        val value = decoder.decodeString()
+        return AssistantStreamEventType.entries.single { value == it.event }
+    }
+    override fun serialize(encoder: Encoder, value: AssistantStreamEventType) {
+        encoder.encodeString(value.event)
+    }
+}

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunRequest.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunRequest.kt
@@ -48,6 +48,11 @@ public data class RunRequest(
      * Keys can be a maximum of 64 characters long, and values can be a maximum of 512 characters long.
      */
     @SerialName("metadata") val metadata: Map<String, String>? = null,
+
+    /**
+     * Enables streaming events for this run. Will be overridden based on the api call being made.
+     */
+    @SerialName("stream") val stream: Boolean = false
 )
 
 /**

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/ThreadRunRequest.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/ThreadRunRequest.kt
@@ -50,6 +50,11 @@ public data class ThreadRunRequest(
      * Keys can be a maximum of 64 characters long, and values can be a maximum of 512 characters long.
      */
     @SerialName("metadata") val metadata: Map<String, String>? = null,
+
+    /**
+     * Enables streaming events for this run. Will be overridden based on the api call being made.
+     */
+    @SerialName("stream") val stream: Boolean = false
 )
 
 /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #319   <!-- will close issue automatically, if any -->

## Describe your change

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

Added support for server-sent event streaming on `createRun`,`createThreadAndRun`, and `submitToolOutput` endpoints. I've added and enum and extension methods to help with deserializing the data field of each event. If new event types are added by OpenAI, before we get a chance to update this library, the new events will be classified as `UNKNOWN` and consumers can implement custom serializers for the time being if desired. Event handling takes place within a Flow and is therefore ordered and handler blocks are suspend functions so the handler block can be made async if desired.

The getting started has usage information for the streaming endpoints.

## What problem is this fixing?

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->

Enables streaming support functions. There are no backwards compatibility issues and streaming has been implemented using new api functions.