### PR TITLE
fix: support for file search tool calls

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunStepDetails.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunStepDetails.kt
@@ -153,7 +153,7 @@ public data class FileSearchToolCallRankingOptions(
     /**
      * The configured ranker.
      */
-    public val ranker: String,
+    @SerialName("ranker") public val ranker: String,
 
     /**
      * The configured score threshold.

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunStepDetails.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/run/RunStepDetails.kt
@@ -47,8 +47,8 @@ public data class MessageCreation(
 public data class ToolCallStepDetails(
     /**
      * An array of tool calls the run step was involved in.
-     * These can be associated with one of three types of tools:
-     * [ToolCallStep.CodeInterpreter], [ToolCallStep.RetrievalTool], or [ToolCallStep.FunctionTool].
+     * These can be associated with one of four types of tools:
+     * [ToolCallStep.CodeInterpreter], [ToolCallStep.RetrievalTool], [ToolCallStep.FunctionTool], or [ToolCallStep.FileSearchTool].
      */
     @SerialName("tool_calls") public val toolCalls: List<ToolCallStep>? = null,
 ) : RunStepDetails
@@ -98,6 +98,20 @@ public sealed interface ToolCallStep {
          */
         @SerialName("function") public val function: FunctionToolCallStep,
     ) : ToolCallStep
+
+    @BetaOpenAI
+    @Serializable
+    @SerialName("file_search")
+    public data class FileSearchTool(
+        /**
+         * The ID of the tool call object.
+         */
+        @SerialName("id") public val id: ToolCallStepId,
+        /**
+         * The options and results of the file search.
+         */
+        @SerialName("file_search") public val fileSearch: FileSearchToolCallStep,
+    ) : ToolCallStep
 }
 
 @BetaOpenAI
@@ -117,6 +131,53 @@ public data class FunctionToolCallStep(
      * The output of the function. This will be null if the outputs have not been submitted yet.
      */
     @SerialName("output") public val output: String? = null,
+)
+
+@BetaOpenAI
+@Serializable
+public data class FileSearchToolCallStep(
+    /**
+     * The configured options for ranking.
+     */
+    @SerialName("ranking_options") public val rankingOptions: FileSearchToolCallRankingOptions,
+
+    /**
+     * The returned results of the file search, ordered by score.
+     */
+    @SerialName("results") public val results: List<FileSearchToolCallResult>,
+)
+
+@BetaOpenAI
+@Serializable
+public data class FileSearchToolCallRankingOptions(
+    /**
+     * The configured ranker.
+     */
+    public val ranker: String,
+
+    /**
+     * The configured score threshold.
+     */
+    @SerialName("score_threshold") public val scoreThreshold: Double,
+)
+
+@BetaOpenAI
+@Serializable
+public data class FileSearchToolCallResult(
+    /**
+     * The ID of the file object.
+     */
+    @SerialName("file_id") public val fileId: FileId,
+
+    /**
+     * The original filename of the file object.
+     */
+    @SerialName("file_name") public val fileName: String,
+
+    /**
+     * The score given to the provided result.
+     */
+    @SerialName("score") public val score: Double,
 )
 
 @BetaOpenAI


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #404 

## Describe your change

Adds `FileSearchTool` to the `ToolCallStep` enum, along with `FileSearchToolCallStep` and other nested objects.

## What problem is this fixing?

When trying to fetch runSteps for a Run that contained any `file_search` tool calls, the response would fail due to serialization issues.