### PR TITLE
Add reasoning effort, max completion tokens, store options for reasoning model support

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionRequest.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionRequest.kt
@@ -26,6 +26,12 @@ public data class ChatCompletionRequest(
     @SerialName("messages") public val messages: List<ChatMessage>,
 
     /**
+     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high.
+     * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+     */
+    @SerialName("reasoning_effort") public val reasoningEffort: Effort? = null,
+
+    /**
      * What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random,
      * while lower values like 0.2 will make it more focused and deterministic.
      *
@@ -192,6 +198,12 @@ public class ChatCompletionRequestBuilder {
     public var messages: List<ChatMessage>? = null
 
     /**
+     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high.
+     * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+     */
+    public val reasoningEffort: Effort? = null
+
+    /**
      * What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random,
      * while lower values like 0.2 will make it more focused and deterministic.
      *
@@ -354,6 +366,7 @@ public class ChatCompletionRequestBuilder {
     public fun build(): ChatCompletionRequest = ChatCompletionRequest(
         model = requireNotNull(model) { "model is required" },
         messages = requireNotNull(messages) { "messages is required" },
+        reasoningEffort = reasoningEffort,
         temperature = temperature,
         topP = topP,
         n = n,

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionRequest.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionRequest.kt
@@ -59,6 +59,11 @@ public data class ChatCompletionRequest(
     @SerialName("stop") public val stop: List<String>? = null,
 
     /**
+     * Whether to store the output of this chat completion request for use in our model distillation or evals products
+     */
+    @SerialName("store") public val store: Boolean? = null,
+
+    /**
      * The maximum number of tokens allowed for the generated answer. By default, the number of tokens the model can
      * return will be (4096 - prompt tokens).
      */
@@ -238,6 +243,11 @@ public class ChatCompletionRequestBuilder {
     public var stop: List<String>? = null
 
     /**
+     * Whether to store the output of this chat completion request for use in our model distillation or evals products
+     */
+    public val store: Boolean? = null
+
+    /**
      * The maximum number of tokens allowed for the generated answer. By default, the number of tokens the model can
      * return will be (4096 - prompt tokens).
      */
@@ -385,6 +395,7 @@ public class ChatCompletionRequestBuilder {
         topP = topP,
         n = n,
         stop = stop,
+        store = store,
         maxTokens = maxTokens,
         maxCompletionTokens = maxCompletionTokens,
         presencePenalty = presencePenalty,

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionRequest.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionRequest.kt
@@ -62,7 +62,14 @@ public data class ChatCompletionRequest(
      * The maximum number of tokens allowed for the generated answer. By default, the number of tokens the model can
      * return will be (4096 - prompt tokens).
      */
+    @Deprecated(message = "Deprecated in favor of `max_completion_tokens`")
     @SerialName("max_tokens") public val maxTokens: Int? = null,
+
+    /**
+     * An upper bound for the number of tokens that can be generated for a completion,
+     * including visible output tokens and reasoning tokens.
+     */
+    @SerialName("max_completion_tokens") public val maxCompletionTokens: Int? = null,
 
     /**
      * Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far,
@@ -234,7 +241,14 @@ public class ChatCompletionRequestBuilder {
      * The maximum number of tokens allowed for the generated answer. By default, the number of tokens the model can
      * return will be (4096 - prompt tokens).
      */
+    @Deprecated(message = "Deprecated in favor of `max_completion_tokens`")
     public var maxTokens: Int? = null
+
+    /**
+     * An upper bound for the number of tokens that can be generated for a completion,
+     * including visible output tokens and reasoning tokens.
+     */
+    public val maxCompletionTokens: Int? = null
 
     /**
      * Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far,
@@ -372,6 +386,7 @@ public class ChatCompletionRequestBuilder {
         n = n,
         stop = stop,
         maxTokens = maxTokens,
+        maxCompletionTokens = maxCompletionTokens,
         presencePenalty = presencePenalty,
         frequencyPenalty = frequencyPenalty,
         logitBias = logitBias,

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/Effort.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/Effort.kt
@@ -1,0 +1,11 @@
+package com.aallam.openai.api.chat
+
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
+
+/**
+ * Reasoning Effort.
+ */
+@Serializable
+@JvmInline
+public value class Effort(public val id: String)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->

## Describe your change

`o3-mini` was released yesterday, and there are several changes to the API.

- Added `reasoning_effort` parameter: This is used to give the model guidance on how many reasoning tokens it should generate before creating a response to the prompt. See [here](https://platform.openai.com/docs/guides/reasoning#reasoning-effort) for more information.
- Deprecated `max_tokens` and add `max_completion_tokens`: This parameter is no longer supported in reasoning models.  See [here](https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens) for more information.
- Add `store` parameter: Option to store the output of chat completion request. See [here](https://platform.openai.com/docs/api-reference/chat/create#chat-create-store)

## What problem is this fixing?

This is to add support to modify options regarding the reasoning models.