### PR TITLE
Update to work with Google Gemini

### DIFF
--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/OpenAIConfig.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/OpenAIConfig.kt
@@ -100,6 +100,11 @@ public class OpenAIHost(
         public val OpenAI: OpenAIHost = OpenAIHost(baseUrl = "https://api.openai.com/v1/")
 
         /**
+         * A pre-configured instance of [OpenAIHost] for Google Gemini`.
+         */
+        public val Gemini: OpenAIHost = OpenAIHost(baseUrl = "https://generativelanguage.googleapis.com/v1beta/openai/")
+
+        /**
          * Creates an instance of [OpenAIHost] configured for Azure hosting with the given resource name, deployment ID,
          * and API version.
          *

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletion.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletion.kt
@@ -15,7 +15,7 @@ public data class ChatCompletion(
     /**
      * A unique id assigned to this completion
      */
-    @SerialName("id") public val id: String,
+    @SerialName("id") public val id: String? = null, // gemini doesn't provide back an id
     /**
      * The creation time in epoch milliseconds.
      */
@@ -43,4 +43,6 @@ public data class ChatCompletion(
      * might impact determinism.
      */
     @SerialName("system_fingerprint") public val systemFingerprint: String? = null,
+
+    @SerialName("citations") public val citations: List<String>? = null,
 )


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | yes
| Related Issue     | Fix #412 

## Describe your change
Enable the id on the ChatCompletion to be nullable. Unfortunately this does technically break backwards compatibility as it was defined as a required field but is not actually provided back by all services that are openai compatible. This is also in direct contradiction of the openai documented standard which states that the id is a required field as well.


## What problem is this fixing?
The inability for Gemini to work correctly.
