### PR TITLE
Update to support required toolchoice mode

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ToolChoice.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ToolChoice.kt
@@ -36,6 +36,9 @@ public sealed interface ToolChoice {
         /** Represents the `none` mode. */
         public val None: ToolChoice = Mode("none")
 
+        /** Represents the `required` mode. */
+        public val Required: ToolChoice = Mode("required")
+
         /** Specifies a function for the model to call **/
         public fun function(name: String): ToolChoice =
             Named(type = ToolType.Function, function = FunctionToolChoice(name = name))


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix #424 

## Describe your change
Define toolchoice for `required` to be in compliance with the documented API specifications mentioned at https://platform.openai.com/docs/guides/function-calling#additional-configurations

## What problem is this fixing?
The inability to easily choose Required as a tool choice option when working with OpenAI APIs
