### PR TITLE
Fix JsonSchema strict to be encoded even if it's default value is true

### DIFF
--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestChatCompletions.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestChatCompletions.kt
@@ -152,7 +152,8 @@ class TestChatCompletions : TestOpenAI() {
             "required" to JsonArray(listOf(
                 JsonPrimitive("question"),
                 JsonPrimitive("response")
-            ))
+            )),
+            "additionalProperties" to JsonPrimitive(false)
         ))
 
         val jsonSchema = JsonSchema(

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatResponseFormat.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatResponseFormat.kt
@@ -56,5 +56,5 @@ public data class JsonSchema(
     /**
      * Whether to enforce strict schema validation
      */
-    @SerialName("strict") val strict: Boolean = true
+    @SerialName("strict") val strict: Boolean? = null
 )


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no

## Describe your change

1.  Make `strict` to be encoded when it is set to `true` in `JsonSchema`
2. Add `additionalProperties` to `jsonSchema()` test, as it is required when `strict` is `true`

## What problem is this fixing?
`strict` `true` in `JsonSchema` was never encoded to json since kotlin Json does not encode default values so openai thinks its `false` by default
When `strict` is `false` and schema has nested classes or lists then `ChatMessage` `content` gets wrapped in extra object like `content": "{\"type\":\"object\",\"properties\":{\"isValid\":true,...` 
instead of  expected `"content": "{\"isValid\":true,...`