### PR TITLE
Make OpenAi interface extend Batch interface

### DIFF
--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/OpenAI.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/OpenAI.kt
@@ -11,7 +11,7 @@ import kotlin.time.Duration.Companion.seconds
  * OpenAI API.
  */
 public interface OpenAI : Completions, Files, Edits, Embeddings, Models, Moderations, FineTunes, Images, Chat, Audio,
-    FineTuning, Assistants, Threads, Runs, Messages, VectorStores, AutoCloseable
+    FineTuning, Assistants, Threads, Runs, Messages, VectorStores, Batch, AutoCloseable
 
 /**
  * Creates an instance of [OpenAI].


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #383 ...  <!-- will close issue automatically, if any -->

## Describe your change

Since version 3.8.0 there is a Batch Api implemented. Though it is not accessible via OpenAI interface
This PR makes OpenAI interface extend Batch interface

## What problem is this fixing?

When you create an instance of OpenAI class using function OpenAI(...), you can't access batch api like `openAI.batch(...), because it doesn't extend it.