### PR TITLE
feat(chat): support annotations field in ChatMessage.kt

### DIFF
--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/Annotations.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/Annotations.kt
@@ -1,0 +1,41 @@
+package com.aallam.openai.api.chat
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class Annotations(
+    /**
+     * Type of annotation. e.g. `url_citation`
+     */
+    val type: String,
+
+    /**
+     * An annotation object will contain the URL and title of the cited source,
+     * as well as the start and end index characters in the model's response where those sources were used.
+     */
+    @SerialName("url_citation")
+    val urlCitation: UrlCitation? = null
+)
+
+@Serializable
+public data class UrlCitation(
+    /**
+     * Start index of characters in the model's response
+     */
+    @SerialName("start_index")
+    val startIndex: Int,
+    /**
+     * End index of characters in the model's response
+     */
+    @SerialName("end_index")
+    val endIndex: Int,
+    /**
+     * URL of the cited source
+     */
+    val url: String,
+    /**
+     * Page title of the cited source
+     */
+    val title: String? = null,
+)

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatMessage.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatMessage.kt
@@ -55,6 +55,11 @@ public data class ChatMessage(
      * Azure Content Filter Offsets
      */
     @SerialName("content_filter_offsets") public val contentFilterOffsets: List<ContentFilterOffsets>? = null,
+
+    /**
+     * Response metadata. May be used for web search `url_citation`, for example
+     */
+    @SerialName("annotations") public val annotations: List<Annotations>? = null
 ) {
 
     public constructor(


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | -

## Describe your change

Add an `annotations` field to ChatMessage class.

## What problem is this fixing?

Support `url_citation` annotation in chat message response

```json
        {
          "type": "url_citation",
          "url_citation": {
            "end_index": 985,
            "start_index": 764,
            "title": "Page title...",
            "url": "https://..."
          }
        }
```
