### PR TITLE
feat(chat): add verbosity parameter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+- **chat**: add verbosity parameter support for controlling response length and detail
+
 ## 4.0.1
 > Published 02 Feb 2025
 

--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestChatCompletions.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestChatCompletions.kt
@@ -302,4 +302,30 @@ class TestChatCompletions : TestOpenAI() {
         assertNotNull(results.last().usage?.completionTokens)
         assertNotNull(results.last().usage?.totalTokens)
     }
+
+    @Test
+    fun chatCompletionsWithVerbosity() = test {
+        val request = chatCompletionRequest {
+            model = ModelId("gpt-4o")
+            verbosity = Verbosity.Low
+            messages {
+                user {
+                    content = "Explain quantum computing"
+                }
+            }
+            maxTokens = 100
+        }
+
+        val completion = openAI.chatCompletion(request)
+        assertTrue { completion.choices.isNotEmpty() }
+        assertNotNull(completion.choices.first().message.content)
+    }
+
+    @Test
+    fun verbosityValues() {
+        // Test that verbosity values are correctly defined
+        assertEquals("low", Verbosity.Low.id)
+        assertEquals("medium", Verbosity.Medium.id)
+        assertEquals("high", Verbosity.High.id)
+    }
 }

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionRequest.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/ChatCompletionRequest.kt
@@ -32,6 +32,12 @@ public data class ChatCompletionRequest(
     @SerialName("reasoning_effort") public val reasoningEffort: Effort? = null,
 
     /**
+     * Constrains the verbosity of responses. Currently supported values are low, medium, and high.
+     * Controls how concise or verbose the model's output will be.
+     */
+    @SerialName("verbosity") public val verbosity: Verbosity? = null,
+
+    /**
      * What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random,
      * while lower values like 0.2 will make it more focused and deterministic.
      *
@@ -213,7 +219,13 @@ public class ChatCompletionRequestBuilder {
      * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high.
      * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
      */
-    public val reasoningEffort: Effort? = null
+    public var reasoningEffort: Effort? = null
+
+    /**
+     * Constrains the verbosity of responses. Currently supported values are low, medium, and high.
+     * Controls how concise or verbose the model's output will be.
+     */
+    public var verbosity: Verbosity? = null
 
     /**
      * What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random,
@@ -391,6 +403,7 @@ public class ChatCompletionRequestBuilder {
         model = requireNotNull(model) { "model is required" },
         messages = requireNotNull(messages) { "messages is required" },
         reasoningEffort = reasoningEffort,
+        verbosity = verbosity,
         temperature = temperature,
         topP = topP,
         n = n,

--- a/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/Verbosity.kt
+++ b/openai-core/src/commonMain/kotlin/com.aallam.openai.api/chat/Verbosity.kt
@@ -1,0 +1,28 @@
+package com.aallam.openai.api.chat
+
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
+
+/**
+ * Verbosity level for controlling response length and detail.
+ */
+@Serializable
+@JvmInline
+public value class Verbosity(public val id: String) {
+    public companion object {
+        /**
+         * Low verbosity - terse, concise responses.
+         */
+        public val Low: Verbosity = Verbosity("low")
+        
+        /**
+         * Medium verbosity - balanced responses (default).
+         */
+        public val Medium: Verbosity = Verbosity("medium")
+        
+        /**
+         * High verbosity - detailed, comprehensive responses.
+         */
+        public val High: Verbosity = Verbosity("high")
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | N/A

## Describe your change

This PR adds support for the new `verbosity` parameter in ChatCompletionRequest, which was introduced with GPT-5 and allows controlling response length and detail.

**Implementation details:**
- Created `Verbosity` value class with predefined Low, Medium, High options
- Added `verbosity` parameter to `ChatCompletionRequest` and `ChatCompletionRequestBuilder`
- Follows the same pattern as existing `reasoningEffort` parameter
- Added comprehensive tests and updated CHANGELOG.md

**Usage:**
```kotlin
val request = chatCompletionRequest {
    model = ModelId("gpt-4o")
    verbosity = Verbosity.Low  // or Medium, High
    messages { /* ... */ }
}
```

## What problem is this fixing?

The OpenAI API recently introduced a `verbosity` parameter for Chat Completions and Responses API endpoints. This parameter allows developers to control how concise or verbose the model's responses are:

- low: Terse, concise responses
- medium: Balanced responses (default)
- high: Detailed, comprehensive responses

Without this parameter, developers cannot take advantage of this new API feature to optimize response length for their specific use cases.