### PR TITLE
Use channel flows to fix ktor 3.4.0 compatibility, closes #461

### DIFF
--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ChatApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/ChatApi.kt
@@ -14,7 +14,7 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.channelFlow
 
 internal class ChatApi(private val requester: HttpRequester) : Chat {
     override suspend fun chatCompletion(
@@ -47,7 +47,7 @@ internal class ChatApi(private val requester: HttpRequester) : Chat {
             }
             requestOptions(requestOptions)
         }
-        return flow {
+        return channelFlow {
             requester.perform(builder) { response -> streamEventsFrom(response) }
         }
     }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/CompletionsApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/CompletionsApi.kt
@@ -11,7 +11,7 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.channelFlow
 
 /**
  * Implementation of [Completions].
@@ -40,7 +40,7 @@ internal class CompletionsApi(private val requester: HttpRequester) : Completion
                 append(HttpHeaders.Connection, "keep-alive")
             }
         }
-        return flow {
+        return channelFlow {
             requester.perform(builder) { response -> streamEventsFrom(response) }
         }
     }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/FineTunesApi.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/api/FineTunesApi.kt
@@ -16,7 +16,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.*
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.channelFlow
 
 /**
  * Implementation of [FineTunes].
@@ -71,7 +71,7 @@ internal class FineTunesApi(private val requester: HttpRequester) : FineTunes {
                 append(HttpHeaders.Connection, "keep-alive")
             }
         }
-        return flow {
+        return channelFlow {
             requester.perform(request) { response -> streamEventsFrom(response) }
         }
     }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/extension/Stream.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/extension/Stream.kt
@@ -4,8 +4,8 @@ import com.aallam.openai.client.internal.JsonLenient
 import io.ktor.client.call.*
 import io.ktor.client.statement.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.isActive
 
 private const val STREAM_PREFIX = "data:"
@@ -14,7 +14,7 @@ private const val STREAM_END_TOKEN = "$STREAM_PREFIX [DONE]"
 /**
  * Get data as [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format).
  */
-internal suspend inline fun <reified T> FlowCollector<T>.streamEventsFrom(response: HttpResponse) {
+internal suspend inline fun <reified T> ProducerScope<T>.streamEventsFrom(response: HttpResponse) {
     val channel: ByteReadChannel = response.body()
     try {
         while (currentCoroutineContext().isActive && !channel.isClosedForRead) {
@@ -24,7 +24,7 @@ internal suspend inline fun <reified T> FlowCollector<T>.streamEventsFrom(respon
                 line.startsWith(STREAM_PREFIX) -> JsonLenient.decodeFromString(line.removePrefix(STREAM_PREFIX))
                 else -> continue
             }
-            emit(value)
+            send(value)
         }
     } finally {
         channel.cancel()


### PR DESCRIPTION
This implements one of the fixes suggested in #461, and was tested successfully in our project. The channel flow approach seems a bit cleaner / more robust than messing around with the context.