### PR TITLE
docs: add Tuning Engines custom host example

### DIFF
--- a/guides/GettingStarted.md
+++ b/guides/GettingStarted.md
@@ -602,6 +602,23 @@ val config = OpenAIConfig(
 val openAI = OpenAI(config)
 ```
 
+For example, Tuning Engines exposes an OpenAI-compatible endpoint for teams that
+want a governed control plane for model access, policy checks, audit logs,
+traces, and usage/cost reporting:
+
+```kotlin
+val host = OpenAIHost(
+    baseUrl = "https://api.tuningengines.com/v1/",
+)
+
+val config = OpenAIConfig(
+    host = host,
+    token = System.getenv("TUNING_ENGINES_API_KEY"),
+)
+
+val openAI = OpenAI(config)
+```
+
 ---
 
 ## Assistants


### PR DESCRIPTION
## Summary
- add a Tuning Engines example to the custom OpenAI-compatible hosts section
- show OpenAIHost with https://api.tuningengines.com/v1/ and TUNING_ENGINES_API_KEY
- keep the change limited to the getting started guide

## Why
We are an AI infrastructure team using openai-kotlin with Tuning Engines. Since the guide already documents custom compatible hosts, this gives Kotlin teams a concrete setup for governed model access, policy checks, traces, audit logs, and usage/cost reporting. It would mean a lot to us if this is useful, and I am happy to adjust the wording or placement.

## Validation
- git diff --check