### PR TITLE
Document OpenAI-compatible base URL configuration

### DIFF
--- a/guides/GettingStarted.md
+++ b/guides/GettingStarted.md
@@ -602,6 +602,23 @@ val config = OpenAIConfig(
 val openAI = OpenAI(config)
 ```
 
+For applications that switch between OpenAI and another OpenAI-compatible
+endpoint across environments, the host can be read from `OPENAI_BASE_URL`.
+The value should include the API base path and end with `/`.
+
+```kotlin
+val host = OpenAIHost(
+    baseUrl = System.getenv("OPENAI_BASE_URL") ?: "https://api.openai.com/v1/",
+)
+
+val config = OpenAIConfig(
+    host = host,
+    token = System.getenv("OPENAI_API_KEY") ?: error("OPENAI_API_KEY is required"),
+)
+
+val openAI = OpenAI(config)
+```
+
 ---
 
 ## Assistants


### PR DESCRIPTION
This keeps the default OpenAI host unchanged while documenting how to configure another OpenAI-compatible endpoint through OPENAI_BASE_URL.\n\nWhy this may be useful:\n- local inference servers\n- private model gateways\n- self-hosted routers\n- observability and enterprise control planes\n\nThe example uses the existing OpenAIHost/OpenAIConfig APIs and does not add a provider-specific integration.